### PR TITLE
feat: browser-based auth flow for API key setup

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -16,7 +16,7 @@ const entries = [
     in: `src/hooks/${n}.ts`,
     out: `dist/hooks/${n}.js`,
   })),
-  ...["search-memory", "save-memory", "forget-memory"].map((n) => ({
+  ...["search-memory", "save-memory", "forget-memory", "login"].map((n) => ({
     in: `src/skills/${n}.ts`,
     out: `dist/skills/${n}.js`,
   })),
@@ -34,7 +34,7 @@ await Promise.all(
 );
 
 // Copy SKILL.md files to dist
-for (const skillName of ["supermemory-search", "supermemory-save", "supermemory-forget"]) {
+for (const skillName of ["supermemory-search", "supermemory-save", "supermemory-forget", "supermemory-login"]) {
   mkdirSync(`dist/skills/${skillName}`, { recursive: true });
   copyFileSync(
     `src/skills/${skillName}/SKILL.md`,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -39,6 +39,7 @@ const SKILLS = [
   { name: "supermemory-search", script: "search-memory.js" },
   { name: "supermemory-save", script: "save-memory.js" },
   { name: "supermemory-forget", script: "forget-memory.js" },
+  { name: "supermemory-login", script: "login.js" },
 ] as const;
 
 const SCRIPT_DIR = getScriptDir();
@@ -251,15 +252,17 @@ Installation complete!
 
 You now have:
   • Implicit memory — auto-recall on every prompt, auto-capture on session end
-  • Explicit memory — supermemory-search, supermemory-save, and supermemory-forget skills
+  • Explicit memory — supermemory-search, supermemory-save, supermemory-forget, and supermemory-login skills
 
 Next steps:
-  1. Add your API key to your shell profile:
-     export SUPERMEMORY_CODEX_API_KEY="sm_..."
+  1. Start Codex — on your first prompt, a browser window will open to
+     authenticate with Supermemory automatically.
 
-  2. Get your API key at: https://console.supermemory.ai/keys
+  Or authenticate manually:
+     /supermemory-login      (inside Codex)
+     export SUPERMEMORY_CODEX_API_KEY="sm_..."   (in your shell profile)
 
-  3. Restart Codex CLI to activate memory.
+  2. Get an API key at: https://console.supermemory.ai/keys (if needed)
 
 Optional: Enable debug logging:
   export SUPERMEMORY_DEBUG=true

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@ import {
   copyFileSync,
   rmSync,
 } from "node:fs";
+import { loadCredentials } from "./services/auth.js";
 import { join, dirname } from "node:path";
 import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
@@ -296,7 +297,15 @@ function uninstall() {
 }
 
 function status() {
-  const apiKey = process.env.SUPERMEMORY_CODEX_API_KEY;
+  const envApiKey = process.env.SUPERMEMORY_CODEX_API_KEY;
+  const credentialsApiKey = !envApiKey ? loadCredentials() : undefined;
+  const apiKey = envApiKey || credentialsApiKey;
+  const apiKeySource = envApiKey
+    ? "SUPERMEMORY_CODEX_API_KEY env var"
+    : credentialsApiKey
+    ? "credentials file (~/.codex/supermemory/credentials.json)"
+    : null;
+
   const hooksInstalled = existsSync(RECALL_SCRIPT) && existsSync(CAPTURE_SCRIPT);
   const hooksJsonExists = existsSync(CODEX_HOOKS_JSON);
   const configTomlExists = existsSync(CODEX_CONFIG_TOML);
@@ -325,7 +334,7 @@ function status() {
   );
 
   console.log("codex-supermemory status:\n");
-  console.log(`  API key:       ${apiKey ? "✓ set (SUPERMEMORY_CODEX_API_KEY)" : "✗ not set"}`);
+  console.log(`  API key:       ${apiKey ? `✓ set (${apiKeySource})` : "✗ not set"}`);
   console.log(`  Hook scripts:  ${hooksInstalled ? `✓ installed at ${SUPERMEMORY_HOOKS_DIR}` : "✗ not installed"}`);
   console.log(`  hooks.json:    ${hooksEnabled ? "✓ registered (implicit memory)" : "✗ not registered"}`);
   console.log(`  Skills:        ${skillsInstalled ? `✓ installed (${SKILLS.map(s => s.name).join(", ")})` : "✗ not installed"}`);

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
+import { loadCredentials } from "./services/auth.js";
 
 const CONFIG_FILE = join(homedir(), ".codex", "supermemory.json");
 
@@ -45,10 +46,14 @@ const fileConfig = loadConfig();
 function getApiKey(): string | undefined {
   if (process.env.SUPERMEMORY_CODEX_API_KEY) return process.env.SUPERMEMORY_CODEX_API_KEY;
   if (fileConfig.apiKey) return fileConfig.apiKey;
-  return undefined;
+  return loadCredentials();
 }
 
-export const SUPERMEMORY_API_KEY = getApiKey();
+export let SUPERMEMORY_API_KEY = getApiKey();
+
+export function reloadApiKey(): void {
+  SUPERMEMORY_API_KEY = getApiKey();
+}
 
 export const CONFIG = {
   similarityThreshold: fileConfig.similarityThreshold ?? DEFAULTS.similarityThreshold,
@@ -64,4 +69,8 @@ export const CONFIG = {
 
 export function isConfigured(): boolean {
   return !!SUPERMEMORY_API_KEY;
+}
+
+export function getApiKeyValue(): string | undefined {
+  return SUPERMEMORY_API_KEY;
 }

--- a/src/hooks/capture.ts
+++ b/src/hooks/capture.ts
@@ -105,6 +105,10 @@ async function main() {
   }
 
   if (!isConfigured()) {
+    process.stderr.write(
+      "[supermemory] Session NOT saved — API key missing. " +
+      "Run: export SUPERMEMORY_CODEX_API_KEY=\"sm_...\"\n"
+    );
     process.exit(0);
   }
 

--- a/src/hooks/recall.ts
+++ b/src/hooks/recall.ts
@@ -1,9 +1,14 @@
-import { readFileSync } from "node:fs";
-import { isConfigured, CONFIG } from "../config.js";
+import { readFileSync, existsSync, writeFileSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { isConfigured, CONFIG, reloadApiKey } from "../config.js";
 import { SupermemoryClient } from "../services/client.js";
 import { getTags } from "../services/tags.js";
 import { formatContextForPrompt } from "../services/context.js";
 import { log } from "../services/logger.js";
+import { startAuthFlow, AUTH_BASE_URL } from "../services/auth.js";
+
+const AUTH_ATTEMPTED_FILE = join(homedir(), ".codex", "supermemory", ".auth-attempted");
 
 interface CodexHookPayload {
   session_id?: string;
@@ -37,7 +42,37 @@ async function main() {
   }
 
   if (!isConfigured()) {
-    exitWithContext("");
+    const alreadyAttempted = existsSync(AUTH_ATTEMPTED_FILE);
+
+    if (!alreadyAttempted) {
+      try {
+        writeFileSync(AUTH_ATTEMPTED_FILE, new Date().toISOString());
+      } catch {}
+
+      try {
+        log("recall: no API key, starting browser auth flow");
+        await startAuthFlow();
+        reloadApiKey();
+        try { unlinkSync(AUTH_ATTEMPTED_FILE); } catch {}
+        log("recall: auth flow completed");
+      } catch (authErr) {
+        const isTimeout =
+          authErr instanceof Error && authErr.message === "AUTH_TIMEOUT";
+        exitWithContext(
+          "[SUPERMEMORY] Memory is installed but NOT active — missing API key.\n" +
+          (isTimeout
+            ? "Authentication timed out. Please complete login in the browser.\n"
+            : "Authentication failed.\n") +
+          `If the browser did not open, visit: ${AUTH_BASE_URL}\n` +
+          "Run /supermemory-login to try again, or set SUPERMEMORY_CODEX_API_KEY manually."
+        );
+      }
+    } else {
+      exitWithContext(
+        "[SUPERMEMORY] Memory is installed but NOT active — missing API key.\n" +
+        "Run /supermemory-login to authenticate, or set SUPERMEMORY_CODEX_API_KEY in your shell profile."
+      );
+    }
   }
 
   let payload: CodexHookPayload = {};

--- a/src/hooks/recall.ts
+++ b/src/hooks/recall.ts
@@ -1,5 +1,5 @@
-import { readFileSync, existsSync, writeFileSync, unlinkSync } from "node:fs";
-import { join } from "node:path";
+import { readFileSync, existsSync, writeFileSync, unlinkSync, mkdirSync } from "node:fs";
+import { join, dirname } from "node:path";
 import { homedir } from "node:os";
 import { isConfigured, CONFIG, reloadApiKey } from "../config.js";
 import { SupermemoryClient } from "../services/client.js";
@@ -46,6 +46,7 @@ async function main() {
 
     if (!alreadyAttempted) {
       try {
+        mkdirSync(dirname(AUTH_ATTEMPTED_FILE), { recursive: true });
         writeFileSync(AUTH_ATTEMPTED_FILE, new Date().toISOString());
       } catch {}
 

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,0 +1,121 @@
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { execFile } from "node:child_process";
+
+const SUPERMEMORY_DIR = join(homedir(), ".codex", "supermemory");
+const CREDENTIALS_FILE = join(SUPERMEMORY_DIR, "credentials.json");
+
+const AUTH_BASE_URL =
+  process.env.SUPERMEMORY_AUTH_URL || "https://app.supermemory.ai/auth/connect";
+const AUTH_PORT = 19877; // different from claude plugin's 19876
+const AUTH_TIMEOUT = 25_000;
+
+const AUTH_SUCCESS_HTML = `<!DOCTYPE html>
+<html><head><title>Connected - Supermemory</title><style>
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;display:flex;flex-direction:column;justify-content:center;align-items:center;min-height:100vh;background:#faf9f6}
+.dot{width:10px;height:10px;background:#22c55e;border-radius:50%;display:inline-block;margin-right:8px}
+h1{font-size:32px;font-weight:500;color:#1a1a1a;margin:16px 0}
+p{color:#666;font-size:16px}
+</style></head><body>
+<div><span class="dot"></span><span style="color:#22c55e;font-size:14px">Connected</span></div>
+<h1>Supermemory is ready</h1>
+<p>You can close this tab and return to Codex.</p>
+</body></html>`;
+
+const AUTH_ERROR_HTML = `<!DOCTYPE html>
+<html><head><title>Error - Supermemory</title><style>
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;display:flex;flex-direction:column;justify-content:center;align-items:center;min-height:100vh;background:#faf9f6}
+.dot{width:10px;height:10px;background:#ef4444;border-radius:50%;display:inline-block;margin-right:8px}
+h1{font-size:32px;font-weight:500;color:#1a1a1a;margin:16px 0}
+p{color:#666;font-size:16px}
+</style></head><body>
+<div><span class="dot"></span><span style="color:#ef4444;font-size:14px">Error</span></div>
+<h1>Connection Failed</h1>
+<p>Invalid API key received. Please try again.</p>
+</body></html>`;
+
+export function loadCredentials(): string | undefined {
+  try {
+    if (existsSync(CREDENTIALS_FILE)) {
+      const data = JSON.parse(readFileSync(CREDENTIALS_FILE, "utf-8")) as {
+        apiKey?: string;
+      };
+      if (data.apiKey) return data.apiKey;
+    }
+  } catch {}
+  return undefined;
+}
+
+function saveCredentials(apiKey: string): void {
+  mkdirSync(SUPERMEMORY_DIR, { recursive: true });
+  writeFileSync(
+    CREDENTIALS_FILE,
+    JSON.stringify({ apiKey, savedAt: new Date().toISOString() }, null, 2)
+  );
+}
+
+function openBrowser(url: string): void {
+  const onError = () => {};
+  if (process.platform === "win32") {
+    execFile("explorer.exe", [url], onError);
+  } else if (process.platform === "darwin") {
+    execFile("open", [url], onError);
+  } else {
+    execFile("xdg-open", [url], onError);
+  }
+}
+
+export function startAuthFlow(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let resolved = false;
+
+    const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+      const url = new URL(req.url || "/", `http://localhost:${AUTH_PORT}`);
+
+      if (url.pathname === "/callback") {
+        const apiKey =
+          url.searchParams.get("apikey") || url.searchParams.get("api_key");
+
+        if (apiKey?.startsWith("sm_")) {
+          saveCredentials(apiKey);
+          res.writeHead(200, { "Content-Type": "text/html" });
+          res.end(AUTH_SUCCESS_HTML);
+          resolved = true;
+          server.close();
+          resolve(apiKey);
+        } else {
+          res.writeHead(400, { "Content-Type": "text/html" });
+          res.end(AUTH_ERROR_HTML);
+        }
+      } else {
+        res.writeHead(404);
+        res.end("Not found");
+      }
+    });
+
+    server.listen(AUTH_PORT, "127.0.0.1", () => {
+      const callbackUrl = `http://localhost:${AUTH_PORT}/callback`;
+      const authUrl = `${AUTH_BASE_URL}?callback=${encodeURIComponent(callbackUrl)}&client=codex`;
+      openBrowser(authUrl);
+    });
+
+    server.on("error", (err) => {
+      if (!resolved) {
+        reject(new Error(`Failed to start auth server: ${err.message}`));
+      }
+    });
+
+    setTimeout(() => {
+      if (!resolved) {
+        server.close();
+        reject(new Error("AUTH_TIMEOUT"));
+      }
+    }, AUTH_TIMEOUT);
+  });
+}
+
+export { AUTH_BASE_URL, CREDENTIALS_FILE };

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { execFile } from "node:child_process";
+import { randomBytes } from "node:crypto";
 
 const SUPERMEMORY_DIR = join(homedir(), ".codex", "supermemory");
 const CREDENTIALS_FILE = join(SUPERMEMORY_DIR, "credentials.json");
@@ -51,10 +52,11 @@ export function loadCredentials(): string | undefined {
 }
 
 function saveCredentials(apiKey: string): void {
-  mkdirSync(SUPERMEMORY_DIR, { recursive: true });
+  mkdirSync(SUPERMEMORY_DIR, { recursive: true, mode: 0o700 });
   writeFileSync(
     CREDENTIALS_FILE,
-    JSON.stringify({ apiKey, savedAt: new Date().toISOString() }, null, 2)
+    JSON.stringify({ apiKey, savedAt: new Date().toISOString() }, null, 2),
+    { mode: 0o600 }
   );
 }
 
@@ -72,11 +74,19 @@ function openBrowser(url: string): void {
 export function startAuthFlow(): Promise<string> {
   return new Promise((resolve, reject) => {
     let resolved = false;
+    const stateToken = randomBytes(16).toString("hex");
 
     const server = createServer((req: IncomingMessage, res: ServerResponse) => {
       const url = new URL(req.url || "/", `http://localhost:${AUTH_PORT}`);
 
       if (url.pathname === "/callback") {
+        const callbackState = url.searchParams.get("state");
+        if (callbackState !== stateToken) {
+          res.writeHead(403, { "Content-Type": "text/html" });
+          res.end(AUTH_ERROR_HTML);
+          return;
+        }
+
         const apiKey =
           url.searchParams.get("apikey") || url.searchParams.get("api_key");
 
@@ -85,6 +95,7 @@ export function startAuthFlow(): Promise<string> {
           res.writeHead(200, { "Content-Type": "text/html" });
           res.end(AUTH_SUCCESS_HTML);
           resolved = true;
+          clearTimeout(timer);
           server.close();
           resolve(apiKey);
         } else {
@@ -99,17 +110,18 @@ export function startAuthFlow(): Promise<string> {
 
     server.listen(AUTH_PORT, "127.0.0.1", () => {
       const callbackUrl = `http://localhost:${AUTH_PORT}/callback`;
-      const authUrl = `${AUTH_BASE_URL}?callback=${encodeURIComponent(callbackUrl)}&client=codex`;
+      const authUrl = `${AUTH_BASE_URL}?callback=${encodeURIComponent(callbackUrl)}&client=codex&state=${stateToken}`;
       openBrowser(authUrl);
     });
 
     server.on("error", (err) => {
       if (!resolved) {
+        clearTimeout(timer);
         reject(new Error(`Failed to start auth server: ${err.message}`));
       }
     });
 
-    setTimeout(() => {
+    const timer = setTimeout(() => {
       if (!resolved) {
         server.close();
         reject(new Error("AUTH_TIMEOUT"));

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,17 +1,17 @@
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
-import { homedir } from "node:os";
+import { homedir, hostname, platform, arch } from "node:os";
 import { execFile } from "node:child_process";
 import { randomBytes } from "node:crypto";
+import type { AddressInfo } from "node:net";
 
 const SUPERMEMORY_DIR = join(homedir(), ".codex", "supermemory");
 const CREDENTIALS_FILE = join(SUPERMEMORY_DIR, "credentials.json");
 
 const AUTH_BASE_URL =
-  process.env.SUPERMEMORY_AUTH_URL || "https://app.supermemory.ai/auth/connect";
-const AUTH_PORT = 19877; // different from claude plugin's 19876
-const AUTH_TIMEOUT = 25_000;
+  process.env.SUPERMEMORY_AUTH_URL || "https://console.supermemory.ai/auth/agent-connect";
+const AUTH_TIMEOUT = Number(process.env.SUPERMEMORY_AUTH_TIMEOUT) || 60_000;
 
 const AUTH_SUCCESS_HTML = `<!DOCTYPE html>
 <html><head><title>Connected - Supermemory</title><style>
@@ -77,7 +77,7 @@ export function startAuthFlow(): Promise<string> {
     const stateToken = randomBytes(16).toString("hex");
 
     const server = createServer((req: IncomingMessage, res: ServerResponse) => {
-      const url = new URL(req.url || "/", `http://localhost:${AUTH_PORT}`);
+      const url = new URL(req.url || "/", "http://localhost");
 
       if (url.pathname === "/callback") {
         const callbackState = url.searchParams.get("state");
@@ -108,9 +108,20 @@ export function startAuthFlow(): Promise<string> {
       }
     });
 
-    server.listen(AUTH_PORT, "127.0.0.1", () => {
-      const callbackUrl = `http://localhost:${AUTH_PORT}/callback`;
-      const authUrl = `${AUTH_BASE_URL}?callback=${encodeURIComponent(callbackUrl)}&client=codex&state=${stateToken}`;
+    // Listen on an ephemeral port to avoid conflicts; embed the state token in
+    // the callback URL so the console redirects it back through the redirect.
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address() as AddressInfo;
+      const callbackUrl = `http://localhost:${port}/callback?state=${stateToken}`;
+      const params = new URLSearchParams({
+        callback: callbackUrl,
+        client: "codex",
+        hostname: hostname(),
+        os: `${platform()}-${arch()}`,
+        cwd: process.cwd(),
+        cli_version: "1.0.0",
+      });
+      const authUrl = `${AUTH_BASE_URL}?${params.toString()}`;
       openBrowser(authUrl);
     });
 

--- a/src/services/client.ts
+++ b/src/services/client.ts
@@ -1,5 +1,5 @@
 import Supermemory from "supermemory";
-import { CONFIG, SUPERMEMORY_API_KEY, isConfigured } from "../config.js";
+import { CONFIG, isConfigured, getApiKeyValue } from "../config.js";
 import { log } from "./logger.js";
 import type {
   ConversationIngestResponse,
@@ -51,7 +51,7 @@ export class SupermemoryClient {
       if (!isConfigured()) {
         throw new Error("SUPERMEMORY_API_KEY not set");
       }
-      this.client = new Supermemory({ apiKey: SUPERMEMORY_API_KEY });
+      this.client = new Supermemory({ apiKey: getApiKeyValue() });
     }
     return this.client;
   }

--- a/src/skills/forget-memory.ts
+++ b/src/skills/forget-memory.ts
@@ -4,10 +4,11 @@ import { getProjectTag, getUserTag } from "../services/tags.js";
 
 async function main(): Promise<void> {
   if (!isConfigured()) {
-    console.log(
-      "Supermemory API key not configured. Set SUPERMEMORY_CODEX_API_KEY environment variable."
+    console.error(
+      "Supermemory is not authenticated.\n" +
+      "Run /supermemory-login to connect, or set SUPERMEMORY_CODEX_API_KEY in your shell profile."
     );
-    process.exit(0);
+    process.exit(1);
   }
 
   const content = process.argv.slice(2).join(" ");

--- a/src/skills/login.ts
+++ b/src/skills/login.ts
@@ -1,0 +1,47 @@
+import { unlinkSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { isConfigured } from "../config.js";
+import { startAuthFlow, AUTH_BASE_URL, CREDENTIALS_FILE } from "../services/auth.js";
+
+const AUTH_ATTEMPTED_FILE = join(homedir(), ".codex", "supermemory", ".auth-attempted");
+
+async function main(): Promise<void> {
+  // Clear the auth-attempted marker so the recall hook will try browser auth again
+  try {
+    if (existsSync(AUTH_ATTEMPTED_FILE)) unlinkSync(AUTH_ATTEMPTED_FILE);
+  } catch {}
+
+  if (isConfigured()) {
+    console.log("Already authenticated with Supermemory. Memory is active.");
+    console.log(`To re-authenticate, remove ${CREDENTIALS_FILE} and run this again.`);
+    return;
+  }
+
+  console.log("Opening browser to authenticate with Supermemory...");
+  console.log(`If the browser does not open, visit: ${AUTH_BASE_URL}`);
+
+  try {
+    await startAuthFlow();
+    try {
+      if (existsSync(AUTH_ATTEMPTED_FILE)) unlinkSync(AUTH_ATTEMPTED_FILE);
+    } catch {}
+    console.log("\nAuthenticated successfully! Supermemory is now active.");
+  } catch (err) {
+    const isTimeout = err instanceof Error && err.message === "AUTH_TIMEOUT";
+    if (isTimeout) {
+      console.error("\nAuthentication timed out. Please try again.");
+    } else {
+      console.error("\nAuthentication failed:", err instanceof Error ? err.message : err);
+    }
+    console.error(`\nAlternatively, set the API key manually:`);
+    console.error(`  export SUPERMEMORY_CODEX_API_KEY="sm_..."`);
+    console.error(`  Get your key at: https://console.supermemory.ai/keys`);
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/src/skills/save-memory.ts
+++ b/src/skills/save-memory.ts
@@ -4,10 +4,11 @@ import { getProjectTag } from "../services/tags.js";
 
 async function main(): Promise<void> {
   if (!isConfigured()) {
-    console.log(
-      "Supermemory API key not configured. Set SUPERMEMORY_CODEX_API_KEY environment variable."
+    console.error(
+      "Supermemory is not authenticated.\n" +
+      "Run /supermemory-login to connect, or set SUPERMEMORY_CODEX_API_KEY in your shell profile."
     );
-    process.exit(0);
+    process.exit(1);
   }
 
   const content = process.argv.slice(2).join(" ");

--- a/src/skills/search-memory.ts
+++ b/src/skills/search-memory.ts
@@ -35,10 +35,11 @@ function parseArgs(args: string[]): ParsedArgs {
 
 async function main(): Promise<void> {
   if (!isConfigured()) {
-    console.log(
-      "Supermemory API key not configured. Set SUPERMEMORY_CODEX_API_KEY environment variable."
+    console.error(
+      "Supermemory is not authenticated.\n" +
+      "Run /supermemory-login to connect, or set SUPERMEMORY_CODEX_API_KEY in your shell profile."
     );
-    process.exit(0);
+    process.exit(1);
   }
 
   const { scope, includeProfile, query } = parseArgs(process.argv.slice(2));

--- a/src/skills/supermemory-login/SKILL.md
+++ b/src/skills/supermemory-login/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: supermemory-login
+description: Log in to Supermemory. Use when the user needs to authenticate, set up their API key, or when memory features report a missing key.
+allowed-tools: Bash(node:*)
+---
+
+# Supermemory Login
+
+Authenticate with Supermemory to enable persistent memory across Codex sessions.
+
+## Usage
+
+```bash
+node ~/.codex/supermemory/login.js
+```
+
+This opens a browser window for authentication. Once complete, the API key is saved automatically and memory features activate immediately.
+
+If the browser does not open, the script prints a URL to visit manually.

--- a/test/unit.mjs
+++ b/test/unit.mjs
@@ -187,7 +187,7 @@ describe("integration: install/uninstall", () => {
     assert.equal(result.status, 0, `install should exit 0: ${result.stderr}`);
 
     const skillsDir = join(codexDir, "skills");
-    for (const skillName of ["supermemory-search", "supermemory-save", "supermemory-forget"]) {
+    for (const skillName of ["supermemory-search", "supermemory-save", "supermemory-forget", "supermemory-login"]) {
       const skillMd = join(skillsDir, skillName, "SKILL.md");
       assert.ok(existsSync(skillMd), `${skillName}/SKILL.md should exist`);
       const content = readFileSync(skillMd, "utf-8");
@@ -207,7 +207,7 @@ describe("integration: install/uninstall", () => {
     assert.equal(uninstallResult.status, 0, `uninstall should exit 0: ${uninstallResult.stderr}`);
 
     const skillsDir = join(codexDir, "skills");
-    for (const skillName of ["supermemory-search", "supermemory-save", "supermemory-forget"]) {
+    for (const skillName of ["supermemory-search", "supermemory-save", "supermemory-forget", "supermemory-login"]) {
       assert.ok(
         !existsSync(join(skillsDir, skillName)),
         `${skillName} skill dir should be removed`
@@ -236,12 +236,26 @@ describe("integration: install/uninstall", () => {
 describe("recall hook output envelope", () => {
   const recallBin = new URL("../dist/hooks/recall.js", import.meta.url).pathname;
 
-  test("outputs hookSpecificOutput envelope when not configured", () => {
-    const result = spawnSync("node", [recallBin], {
-      input: JSON.stringify({ session_id: "s1", prompt: "hello" }),
-      env: { ...process.env, SUPERMEMORY_CODEX_API_KEY: "" },
+  // Helper: run recall hook with an isolated HOME so the .auth-attempted file is
+  // writable. Without this, the recall hook cannot persist the "already attempted"
+  // marker (directory doesn't exist), causing every no-key invocation to spin up a
+  // 25-second browser auth flow and timing out — making tests extremely slow.
+  function runRecallUnconfigured(t, input) {
+    const tmpDir = makeTmpDir();
+    mkdirSync(join(tmpDir, ".codex", "supermemory"), { recursive: true });
+    t.after(() => rmSync(tmpDir, { recursive: true, force: true }));
+    return spawnSync("node", [recallBin], {
+      input,
+      env: { ...process.env, HOME: tmpDir, SUPERMEMORY_CODEX_API_KEY: "" },
       encoding: "utf-8",
+      // Generous timeout: first invocation writes .auth-attempted then times out
+      // after AUTH_TIMEOUT (25s). Set timeout slightly above that.
+      timeout: 30_000,
     });
+  }
+
+  test("outputs hookSpecificOutput envelope when not configured", (t) => {
+    const result = runRecallUnconfigured(t, JSON.stringify({ session_id: "s1", prompt: "hello" }));
     const parsed = JSON.parse(result.stdout);
     assert.ok("hookSpecificOutput" in parsed, "must have hookSpecificOutput key");
     assert.equal(parsed.hookSpecificOutput.hookEventName, "UserPromptSubmit");
@@ -269,20 +283,35 @@ describe("recall hook output envelope", () => {
     assert.equal(parsed.hookSpecificOutput.hookEventName, "UserPromptSubmit");
   });
 
-  test("never outputs bare additionalContext at top level (old wrong shape)", () => {
+  test("never outputs bare additionalContext at top level (old wrong shape)", (t) => {
+    // When .auth-attempted already exists (second invocation), the hook exits quickly.
+    // Create it ahead of time so this test doesn't incur the 25s auth timeout.
+    const tmpDir = makeTmpDir();
+    const supermemoryDir = join(tmpDir, ".codex", "supermemory");
+    mkdirSync(supermemoryDir, { recursive: true });
+    writeFileSync(join(supermemoryDir, ".auth-attempted"), new Date().toISOString());
+    t.after(() => rmSync(tmpDir, { recursive: true, force: true }));
+
     const result = spawnSync("node", [recallBin], {
       input: JSON.stringify({ prompt: "test" }),
-      env: { ...process.env, SUPERMEMORY_CODEX_API_KEY: "" },
+      env: { ...process.env, HOME: tmpDir, SUPERMEMORY_CODEX_API_KEY: "" },
       encoding: "utf-8",
     });
     const parsed = JSON.parse(result.stdout);
     assert.ok(!("additionalContext" in parsed), "must NOT have top-level additionalContext");
   });
 
-  test("exits with code 0", () => {
+  test("exits with code 0", (t) => {
+    // Pre-create .auth-attempted so the hook returns quickly without the 25s timeout.
+    const tmpDir = makeTmpDir();
+    const supermemoryDir = join(tmpDir, ".codex", "supermemory");
+    mkdirSync(supermemoryDir, { recursive: true });
+    writeFileSync(join(supermemoryDir, ".auth-attempted"), new Date().toISOString());
+    t.after(() => rmSync(tmpDir, { recursive: true, force: true }));
+
     const result = spawnSync("node", [recallBin], {
       input: JSON.stringify({ prompt: "test" }),
-      env: { ...process.env, SUPERMEMORY_CODEX_API_KEY: "" },
+      env: { ...process.env, HOME: tmpDir, SUPERMEMORY_CODEX_API_KEY: "" },
       encoding: "utf-8",
     });
     assert.equal(result.status, 0);
@@ -393,23 +422,23 @@ describe("skill scripts: search/save/forget", () => {
     });
   }
 
-  test("search-memory prints not-configured message and exits 0 when no API key", (t) => {
+  test("search-memory prints not-configured message and exits 1 when no API key", (t) => {
     const result = runSkillUnconfigured(t, searchBin, ["hello"]);
-    assert.equal(result.status, 0);
-    assert.match(result.stdout, /Supermemory API key not configured/);
-    assert.match(result.stdout, /SUPERMEMORY_CODEX_API_KEY/);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /Supermemory is not authenticated/);
+    assert.match(result.stderr, /supermemory-login/);
   });
 
-  test("save-memory prints not-configured message and exits 0 when no API key", (t) => {
+  test("save-memory prints not-configured message and exits 1 when no API key", (t) => {
     const result = runSkillUnconfigured(t, saveBin, ["some content"]);
-    assert.equal(result.status, 0);
-    assert.match(result.stdout, /Supermemory API key not configured/);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /Supermemory is not authenticated/);
   });
 
-  test("forget-memory prints not-configured message and exits 0 when no API key", (t) => {
+  test("forget-memory prints not-configured message and exits 1 when no API key", (t) => {
     const result = runSkillUnconfigured(t, forgetBin, ["some content"]);
-    assert.equal(result.status, 0);
-    assert.match(result.stdout, /Supermemory API key not configured/);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /Supermemory is not authenticated/);
   });
 
   test("search-memory prints usage and exits 0 when no query is given", (t) => {
@@ -446,10 +475,10 @@ describe("skill scripts: search/save/forget", () => {
       ["--user", "--no-profile", "find", "thing"],
     ]) {
       const result = runSkillUnconfigured(t, searchBin, args);
-      assert.equal(result.status, 0, `flags ${args.join(" ")} should exit 0`);
+      assert.equal(result.status, 1, `flags ${args.join(" ")} should exit 1 when unconfigured`);
       assert.match(
-        result.stdout,
-        /Supermemory API key not configured/,
+        result.stderr,
+        /Supermemory is not authenticated/,
         `flags ${args.join(" ")} should hit the unconfigured branch`
       );
     }

--- a/test/unit.mjs
+++ b/test/unit.mjs
@@ -236,21 +236,18 @@ describe("integration: install/uninstall", () => {
 describe("recall hook output envelope", () => {
   const recallBin = new URL("../dist/hooks/recall.js", import.meta.url).pathname;
 
-  // Helper: run recall hook with an isolated HOME so the .auth-attempted file is
-  // writable. Without this, the recall hook cannot persist the "already attempted"
-  // marker (directory doesn't exist), causing every no-key invocation to spin up a
-  // 25-second browser auth flow and timing out — making tests extremely slow.
+  // Helper: run recall hook with an isolated HOME and a short auth timeout so
+  // the first-invocation browser flow times out in 2s rather than 60s.
   function runRecallUnconfigured(t, input) {
     const tmpDir = makeTmpDir();
     mkdirSync(join(tmpDir, ".codex", "supermemory"), { recursive: true });
     t.after(() => rmSync(tmpDir, { recursive: true, force: true }));
     return spawnSync("node", [recallBin], {
       input,
-      env: { ...process.env, HOME: tmpDir, SUPERMEMORY_CODEX_API_KEY: "" },
+      // Use a 2s auth timeout so the browser flow times out quickly in CI.
+      env: { ...process.env, HOME: tmpDir, SUPERMEMORY_CODEX_API_KEY: "", SUPERMEMORY_AUTH_TIMEOUT: "2000" },
       encoding: "utf-8",
-      // Generous timeout: first invocation writes .auth-attempted then times out
-      // after AUTH_TIMEOUT (25s). Set timeout slightly above that.
-      timeout: 30_000,
+      timeout: 5_000,
     });
   }
 


### PR DESCRIPTION
## Summary

- Adds browser-based OAuth-style auth flow (port from claude-supermemory plugin) — on first use with no API key, opens `app.supermemory.ai/auth/connect` in the browser, receives the key via local callback server, and saves it to `~/.codex/supermemory/credentials.json`
- Adds `/supermemory-login` skill for manual re-authentication
- All hooks and skills now surface clear error messages pointing to the login flow instead of silently failing
- Recall hook triggers browser auth automatically on first prompt (once per install, not every prompt)
- Capture hook writes a stderr warning when unconfigured

## How it works

1. User installs: `npx codex-supermemory install`
2. User starts Codex and sends first prompt
3. Browser opens to Supermemory auth page
4. User logs in → browser redirects to `localhost:19877/callback?apikey=sm_...`
5. Key saved, memory immediately active — no env var needed

Fallbacks: `/supermemory-login` skill, or manual `export SUPERMEMORY_CODEX_API_KEY="sm_..."`.

## Test plan

- [ ] Fresh install with no API key → verify browser opens on first prompt
- [ ] Complete auth in browser → verify credentials.json is created and memory works
- [ ] Close browser without completing auth → verify timeout message appears
- [ ] Second prompt after failed auth → verify it shows the warning (doesn't re-open browser)
- [ ] Run `/supermemory-login` → verify it clears the attempt marker and re-opens browser
- [ ] Run `/supermemory-login` when already authenticated → verify it says already connected
- [ ] Skills (search/save/forget) without key → verify clear error message mentioning /supermemory-login

🤖 Generated with [Claude Code](https://claude.com/claude-code)