### PR TITLE
Fix Codex memory document grouping

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ and the lessons learned across every project — automatically.
   `UserPromptSubmit` hook.
 - 💾 **Automatic capture** — conversations are stored incrementally (every N turns) and
   at session end via the `Stop` hook.
-- 🏷️ **Project + user scoping** — memories are tagged per-project and per-user so
-  context never leaks across repos.
+- 🏷️ **Project + user scoping** — automatic session memories are stored per-user,
+  while explicit project knowledge is tagged per-repo so context never leaks across repos.
 - 🔒 **Privacy-aware** — anything wrapped in `<private>...</private>` is redacted
   before being sent to Supermemory.
 - ⚡ **Zero-config install** — one command sets up `~/.codex/config.toml` and
@@ -87,7 +87,7 @@ Drop this file in to override defaults:
 | `injectProfile`          | `boolean`  | `true`         | Whether to fetch and inject the user profile.                                                |
 | `containerTagPrefix`     | `string`   | `"codex"`      | Prefix for auto-generated container tags.                                                    |
 | `userContainerTag`       | `string`   | auto           | Override the user container tag.                                                             |
-| `projectContainerTag`    | `string`   | auto (per-cwd) | Override the project container tag.                                                          |
+| `projectContainerTag`    | `string`   | auto (per-repo) | Override the project container tag.                                                         |
 | `filterPrompt`           | `string`   | (sensible)     | Filter prompt used by Supermemory's stateful filter.                                         |
 | `debug`                  | `boolean`  | `false`        | Enable debug logging.                                                                        |
 | `autoSaveEveryTurns`     | `number`   | `3`            | Save memories every N turns (incremental capture).                                           |
@@ -95,8 +95,10 @@ Drop this file in to override defaults:
 | `signalKeywords`         | `string[]` | (defaults)     | Keywords that trigger signal extraction.                                                     |
 | `signalTurnsBefore`      | `number`   | `3`            | Include N turns before a signal for context.                                                 |
 
-User and project tags are auto-derived from your `git config user.email` and the
-current working directory (both hashed) when not explicitly set.
+User tags are auto-derived from your `git config user.email`. Project tags are
+derived from the Git common directory when available, so linked worktrees and
+Conductor workspaces for the same repository share one project container by default.
+Set `SUPERMEMORY_ISOLATE_WORKTREES=true` to keep each worktree isolated.
 
 ### Signal extraction (optional)
 

--- a/build.mjs
+++ b/build.mjs
@@ -10,7 +10,7 @@ const sharedConfig = {
   sourcemap: false,
 };
 
-const entries = [
+const executableEntries = [
   { in: "src/cli.ts", out: "dist/cli.js" },
   ...["recall", "flush"].map((n) => ({
     in: `src/hooks/${n}.ts`,
@@ -22,15 +22,29 @@ const entries = [
   })),
 ];
 
+const libraryEntries = [
+  { in: "src/services/session.ts", out: "dist/services/session.js" },
+  { in: "src/services/tags.ts", out: "dist/services/tags.js" },
+];
+
 await Promise.all(
-  entries.map((e) =>
-    esbuild.build({
-      ...sharedConfig,
-      entryPoints: [e.in],
-      outfile: e.out,
-      banner: { js: "#!/usr/bin/env node" },
-    })
-  )
+  [
+    ...executableEntries.map((e) =>
+      esbuild.build({
+        ...sharedConfig,
+        entryPoints: [e.in],
+        outfile: e.out,
+        banner: { js: "#!/usr/bin/env node" },
+      })
+    ),
+    ...libraryEntries.map((e) =>
+      esbuild.build({
+        ...sharedConfig,
+        entryPoints: [e.in],
+        outfile: e.out,
+      })
+    ),
+  ]
 );
 
 // Copy SKILL.md files to dist
@@ -48,7 +62,7 @@ mkdirSync("dist", { recursive: true });
 writeFileSync("dist/package.json", JSON.stringify({ type: "commonjs" }, null, 2));
 
 // Make the executables actually executable.
-for (const e of entries) {
+for (const e of executableEntries) {
   try {
     chmodSync(e.out, 0o755);
   } catch {

--- a/src/hooks/flush.ts
+++ b/src/hooks/flush.ts
@@ -4,6 +4,7 @@ import { SupermemoryClient } from "../services/client.js";
 import { getTags } from "../services/tags.js";
 import { log } from "../services/logger.js";
 import { captureEntries, resolveTranscriptPath } from "../services/capture.js";
+import { getSessionId } from "../services/session.js";
 
 interface CodexStopPayload {
   session_id?: string;
@@ -31,9 +32,9 @@ async function main() {
     return;
   }
 
-  const sessionId = payload.session_id || `codex_${Date.now()}`;
   const cwd = payload.cwd || process.cwd();
   const tags = getTags(cwd);
+  const sessionId = getSessionId(payload.session_id, tags.project);
 
   const transcriptPath = resolveTranscriptPath(payload.transcript_path, sessionId);
 

--- a/src/hooks/recall.ts
+++ b/src/hooks/recall.ts
@@ -9,6 +9,7 @@ import { log } from "../services/logger.js";
 import { startAuthFlow, AUTH_BASE_URL } from "../services/auth.js";
 import { captureEntries, resolveTranscriptPath } from "../services/capture.js";
 import { getSeenFacts, addSeenFacts } from "../services/factCache.js";
+import { getSessionId } from "../services/session.js";
 
 const AUTH_ATTEMPTED_FILE = join(homedir(), ".codex", "supermemory", ".auth-attempted");
 
@@ -94,9 +95,9 @@ async function main() {
     exitWithContext("");
   }
 
-  const sessionId = payload.session_id || `codex_${Date.now()}`;
   const cwd = payload.cwd || process.cwd();
   const tags = getTags(cwd);
+  const sessionId = getSessionId(payload.session_id, tags.project);
 
   log("recall: start", { query: query.slice(0, 100), tags, sessionId });
 

--- a/src/services/capture.ts
+++ b/src/services/capture.ts
@@ -1,7 +1,7 @@
 /**
  * Shared capture logic used by both recall and flush hooks.
  * Reads transcript entries since last capture, filters by signals,
- * and saves to both project and user containers.
+ * and saves to the user container.
  */
 import { existsSync } from "node:fs";
 import { SupermemoryClient } from "./client.js";
@@ -36,7 +36,7 @@ export function resolveTranscriptPath(
 
 /**
  * Capture new transcript entries since last capture, filter by signals,
- * and save to both project and user containers.
+ * and save to the user container.
  *
  * @param caller   Label for log messages (e.g. "recall" or "flush")
  * @param client   Supermemory API client
@@ -131,13 +131,11 @@ export async function captureEntries(
     timestamp: new Date().toISOString(),
   };
 
-  // Save to both project and user containers.
+  // Save automatic transcript capture to the user container. Explicit project
+  // knowledge is still saved via the supermemory-save skill.
   // Use customId so all session turns go into the same document.
   try {
-    await Promise.all([
-      client.addMemory(content, tags.project, metadata, { customId: `${sessionId}_project` }),
-      client.addMemory(content, tags.user, metadata, { customId: `${sessionId}_user` }),
-    ]);
+    await client.addMemory(content, tags.user, metadata, { customId: sessionId });
 
     const lastEntry = newEntries[newEntries.length - 1];
     setLastCapturedIndex(sessionId, lastEntry.index);

--- a/src/services/session.ts
+++ b/src/services/session.ts
@@ -1,0 +1,20 @@
+import { createHash } from "node:crypto";
+
+const FOUR_HOURS_MS = 4 * 60 * 60 * 1000;
+
+function sha256(input: string): string {
+  return createHash("sha256").update(input).digest("hex").slice(0, 16);
+}
+
+export function getFourHourBucket(date = new Date()): number {
+  return Math.floor(date.getTime() / FOUR_HOURS_MS);
+}
+
+export function getSessionId(
+  providedSessionId: string | null | undefined,
+  scope: string,
+  date = new Date(),
+): string {
+  if (providedSessionId?.trim()) return providedSessionId;
+  return `codex_${sha256(`${scope}:${getFourHourBucket(date)}`)}`;
+}

--- a/src/services/tags.ts
+++ b/src/services/tags.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import { execSync } from "node:child_process";
 import { hostname } from "node:os";
+import { basename, dirname, resolve, sep } from "node:path";
 import { CONFIG } from "../config.js";
 
 function sha256(input: string): string {
@@ -19,6 +20,54 @@ function getGitEmail(): string | null {
   }
 }
 
+function getGitRoot(directory: string): string | null {
+  const isolateWorktrees = process.env.SUPERMEMORY_ISOLATE_WORKTREES === "true";
+
+  try {
+    if (isolateWorktrees) {
+      const gitRoot = execSync("git rev-parse --show-toplevel", {
+        cwd: directory,
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+      }).trim();
+      return gitRoot || null;
+    }
+
+    const gitCommonDir = execSync("git rev-parse --git-common-dir", {
+      cwd: directory,
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+
+    if (gitCommonDir === ".git") {
+      const gitRoot = execSync("git rev-parse --show-toplevel", {
+        cwd: directory,
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+      }).trim();
+      return gitRoot || null;
+    }
+
+    const resolved = resolve(directory, gitCommonDir);
+
+    if (
+      basename(resolved) === ".git" &&
+      !resolved.includes(`${sep}.git${sep}`)
+    ) {
+      return dirname(resolved);
+    }
+
+    const gitRoot = execSync("git rev-parse --show-toplevel", {
+      cwd: directory,
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+    return gitRoot || null;
+  } catch {
+    return null;
+  }
+}
+
 export function getUserTag(): string {
   if (CONFIG.userContainerTag) return CONFIG.userContainerTag;
   const email = getGitEmail();
@@ -29,7 +78,8 @@ export function getUserTag(): string {
 
 export function getProjectTag(directory: string): string {
   if (CONFIG.projectContainerTag) return CONFIG.projectContainerTag;
-  return `${CONFIG.containerTagPrefix}_project_${sha256(directory)}`;
+  const basePath = getGitRoot(directory) || directory;
+  return `${CONFIG.containerTagPrefix}_project_${sha256(basePath)}`;
 }
 
 export function getTags(directory: string): { user: string; project: string } {

--- a/test/unit.mjs
+++ b/test/unit.mjs
@@ -5,8 +5,9 @@
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { writeFileSync, readFileSync, mkdirSync, rmSync, existsSync } from "node:fs";
-import { join } from "node:path";
+import { basename, dirname, join, resolve, sep } from "node:path";
 import { tmpdir } from "node:os";
 import * as TOML from "@iarna/toml";
 
@@ -41,10 +42,161 @@ function readToml(path) {
   return TOML.parse(readFileSync(path, "utf-8"));
 }
 
+function hash16(input) {
+  return createHash("sha256").update(input).digest("hex").slice(0, 16);
+}
+
 // Inline the stripPrivateContent logic (mirrors src/services/privacy.ts exactly)
 function stripPrivateContent(s) {
   return s.replace(/<private>[\s\S]*?<\/private>/gi, "[REDACTED]");
 }
+
+// ─── container tags ─────────────────────────────────────────────────────────
+
+describe("container tags", () => {
+  const tagsModule = new URL("../dist/services/tags.js", import.meta.url).href;
+
+  function runGit(args, cwd) {
+    const result = spawnSync("git", args, { cwd, encoding: "utf-8" });
+    assert.equal(
+      result.status,
+      0,
+      `git ${args.join(" ")} failed:\n${result.stderr || result.stdout}`
+    );
+    return result.stdout.trim();
+  }
+
+  function getProjectTagFor(cwd, home, extraEnv = {}) {
+    const script = `
+      import { getProjectTag } from ${JSON.stringify(tagsModule)};
+      console.log(getProjectTag(process.argv.at(-1)));
+    `;
+    const result = spawnSync("node", ["--input-type=module", "-e", script, cwd], {
+      env: {
+        ...process.env,
+        HOME: home,
+        SUPERMEMORY_CODEX_API_KEY: "sm_test",
+        ...extraEnv,
+      },
+      encoding: "utf-8",
+    });
+    assert.equal(result.status, 0, `getProjectTag failed: ${result.stderr}`);
+    return result.stdout.trim();
+  }
+
+  test("project tag uses the shared git common directory for worktrees", (t) => {
+    const tmpDir = makeTmpDir();
+    t.after(() => rmSync(tmpDir, { recursive: true, force: true }));
+
+    const repoDir = join(tmpDir, "repo");
+    const worktreeDir = join(tmpDir, "worktree");
+    const homeDir = join(tmpDir, "home");
+    mkdirSync(repoDir, { recursive: true });
+    mkdirSync(homeDir, { recursive: true });
+
+    runGit(["init"], repoDir);
+    runGit(["config", "user.email", "test@example.com"], repoDir);
+    runGit(["config", "user.name", "Test User"], repoDir);
+    writeFileSync(join(repoDir, "README.md"), "# test\n");
+    runGit(["add", "README.md"], repoDir);
+    runGit(["commit", "-m", "initial"], repoDir);
+    runGit(["worktree", "add", "--detach", worktreeDir, "HEAD"], repoDir);
+    const gitCommonDir = runGit(["rev-parse", "--git-common-dir"], worktreeDir);
+    const resolvedCommonDir = resolve(worktreeDir, gitCommonDir);
+    const expectedBasePath =
+      basename(resolvedCommonDir) === ".git" &&
+      !resolvedCommonDir.includes(`${sep}.git${sep}`)
+        ? dirname(resolvedCommonDir)
+        : runGit(["rev-parse", "--show-toplevel"], worktreeDir);
+
+    assert.equal(
+      getProjectTagFor(worktreeDir, homeDir),
+      `codex_project_${hash16(expectedBasePath)}`
+    );
+  });
+
+  test("project tag can still isolate individual worktrees when requested", (t) => {
+    const tmpDir = makeTmpDir();
+    t.after(() => rmSync(tmpDir, { recursive: true, force: true }));
+
+    const repoDir = join(tmpDir, "repo");
+    const worktreeDir = join(tmpDir, "worktree");
+    const homeDir = join(tmpDir, "home");
+    mkdirSync(repoDir, { recursive: true });
+    mkdirSync(homeDir, { recursive: true });
+
+    runGit(["init"], repoDir);
+    runGit(["config", "user.email", "test@example.com"], repoDir);
+    runGit(["config", "user.name", "Test User"], repoDir);
+    writeFileSync(join(repoDir, "README.md"), "# test\n");
+    runGit(["add", "README.md"], repoDir);
+    runGit(["commit", "-m", "initial"], repoDir);
+    runGit(["worktree", "add", "--detach", worktreeDir, "HEAD"], repoDir);
+    const worktreeRoot = runGit(["rev-parse", "--show-toplevel"], worktreeDir);
+
+    assert.equal(
+      getProjectTagFor(worktreeDir, homeDir, { SUPERMEMORY_ISOLATE_WORKTREES: "true" }),
+      `codex_project_${hash16(worktreeRoot)}`
+    );
+  });
+});
+
+// ─── session ids ────────────────────────────────────────────────────────────
+
+describe("session ids", () => {
+  const sessionModule = new URL("../dist/services/session.js", import.meta.url).href;
+
+  function getSessionIdFor(providedSessionId, scope, isoDate) {
+    const script = `
+      import { getSessionId } from ${JSON.stringify(sessionModule)};
+      const provided = process.argv[1] === "__null__" ? null : process.argv[1];
+      console.log(getSessionId(provided, process.argv[2], new Date(process.argv[3])));
+    `;
+    const result = spawnSync(
+      "node",
+      [
+        "--input-type=module",
+        "-e",
+        script,
+        providedSessionId ?? "__null__",
+        scope,
+        isoDate,
+      ],
+      { encoding: "utf-8" }
+    );
+    assert.equal(result.status, 0, `getSessionId failed: ${result.stderr}`);
+    return result.stdout.trim();
+  }
+
+  test("uses Codex session_id when provided", () => {
+    assert.equal(
+      getSessionIdFor("s1", "codex_project_abc", "2026-05-17T05:59:00.000Z"),
+      "s1"
+    );
+  });
+
+  test("fallback session id is stable within the same 4-hour window", () => {
+    const early = getSessionIdFor(null, "codex_project_abc", "2026-05-17T04:00:00.000Z");
+    const late = getSessionIdFor(null, "codex_project_abc", "2026-05-17T07:59:59.999Z");
+
+    assert.match(early, /^codex_[a-f0-9]{16}$/);
+    assert.equal(early, late);
+  });
+
+  test("fallback session id changes at the next 4-hour window", () => {
+    const current = getSessionIdFor(null, "codex_project_abc", "2026-05-17T07:59:59.999Z");
+    const next = getSessionIdFor(null, "codex_project_abc", "2026-05-17T08:00:00.000Z");
+
+    assert.notEqual(current, next);
+  });
+
+  test("fallback session id is scoped by project tag", () => {
+    const first = getSessionIdFor(null, "codex_project_abc", "2026-05-17T04:00:00.000Z");
+    const second = getSessionIdFor(null, "codex_project_def", "2026-05-17T04:00:00.000Z");
+
+    assert.notEqual(first, second);
+  });
+});
 
 // ─── stripPrivateContent ────────────────────────────────────────────────────
 


### PR DESCRIPTION
Updates Codex memory capture to group automatic session transcripts into the user container only, using the session id as the document custom id. Project tags now derive from the Git common directory by default so Conductor/worktree checkouts share the same project container, with SUPERMEMORY_ISOLATE_WORKTREES available for opt-in isolation. Adds a deterministic 4-hour fallback session id when Codex does not provide session_id. Adds unit coverage for worktree tag behavior and fallback session id bucketing.\n\nValidation: npm test; npm run typecheck.