### PR TITLE
Reasoned per-turn memory recall with auto-approve

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,11 @@ and the lessons learned across every project — automatically.
 
 ## Features
 
-- 🧠 **Automatic recall** — relevant memories are injected into every prompt via the
-  `UserPromptSubmit` hook.
+- 🧠 **Reasoned recall** — before each turn a short directive is injected (via the
+  `UserPromptSubmit` hook) that lets the model decide whether recalling saved memory
+  would actually help this message. When it decides yes, it runs the
+  `supermemory-search` skill — which a `PreToolUse` hook auto-approves so the search
+  stays silent, just like the save path.
 - 💾 **Automatic capture** — conversations are stored incrementally (every N turns) and
   at session end via the `Stop` hook.
 - 🏷️ **Project + user scoping** — memories are tagged per-project and per-user so
@@ -52,12 +55,20 @@ and the lessons learned across every project — automatically.
 ## How it works
 
 Codex CLI supports a hooks system that lets external scripts run at specific
-lifecycle events. `codex-supermemory` registers two hooks:
+lifecycle events. `codex-supermemory` registers these hooks:
 
-| Hook              | Event                  | What it does                                                        |
-| ----------------- | ---------------------- | ------------------------------------------------------------------- |
-| `recall`          | `UserPromptSubmit`     | Captures new turns (every N prompts), then searches Supermemory for relevant memories and your profile, injecting them into the prompt as `additionalContext`. |
-| `flush`           | `Stop`                 | Captures any remaining turns at session end so the final conversation turns are never lost. |
+| Hook             | Event              | What it does                                                        |
+| ---------------- | ------------------ | ------------------------------------------------------------------- |
+| `session-start`  | `SessionStart`     | Loads your user profile and injects it once at the start of the session. |
+| `recall`         | `UserPromptSubmit` | Captures new turns (every N prompts), then injects the reasoned-recall directive so the model decides per turn whether to search. (Legacy `autoRecallEveryPrompt` mode instead searches eagerly on every prompt and injects the results.) |
+| `recall-approve` | `PreToolUse`       | Auto-approves **only** a clean `supermemory-search` call (`node … search-memory.js`, no shell chaining) so reasoned recall runs without a permission prompt. Everything else falls through to Codex's normal approval flow. |
+| `flush`          | `Stop`             | Captures any remaining turns at session end so the final conversation turns are never lost. |
+
+**Reasoned recall**: In the default mode the recall hook doesn't search itself — it
+injects a directive and lets the model decide, per message, whether pulling saved
+memory would help. The `recall-approve` hook then rubber-stamps the resulting search
+so it feels as silent as the save path. Tune the directive text with `recallDirective`
+(see below). Set `autoRecallEveryPrompt: true` to fall back to the legacy eager search.
 
 **Incremental capture**: Memories are saved every N turns (default: 3) during the session.
 This means memories from earlier in your session are immediately available for recall
@@ -102,6 +113,8 @@ Drop this file in to override defaults:
 | `filterPrompt`           | `string`   | (sensible)     | Filter prompt used by Supermemory's stateful filter.                                         |
 | `debug`                  | `boolean`  | `false`        | Enable debug logging.                                                                        |
 | `autoSaveEveryTurns`     | `number`   | `3`            | Save memories every N turns (incremental capture).                                           |
+| `autoRecallEveryPrompt`  | `boolean`  | `false`        | Legacy eager recall: search and inject results on every prompt instead of reasoned recall. (Defaults to `true` for installs upgraded from older versions.) |
+| `recallDirective`        | `string`   | (built-in)     | Override the reasoned-recall directive text injected before each turn.                        |
 | `signalExtraction`       | `boolean`  | `false`        | Enable signal-based filtering (only capture turns with keywords like "prefer", "decided").   |
 | `signalKeywords`         | `string[]` | (defaults)     | Keywords that trigger signal extraction.                                                     |
 | `signalTurnsBefore`      | `number`   | `3`            | Include N turns before a signal for context.                                                 |

--- a/build.mjs
+++ b/build.mjs
@@ -12,7 +12,7 @@ const sharedConfig = {
 
 const executableEntries = [
   { in: "src/cli.ts", out: "dist/cli.js" },
-  ...["recall", "flush", "session-start"].map((n) => ({
+  ...["recall", "recall-approve", "flush", "session-start"].map((n) => ({
     in: `src/hooks/${n}.ts`,
     out: `dist/hooks/${n}.js`,
   })),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-supermemory",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-supermemory",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-supermemory",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Persistent memory for OpenAI Codex CLI — powered by Supermemory",
   "type": "module",
   "main": "dist/cli.js",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -148,10 +148,6 @@ function normalizeHookEvents(raw: unknown): HookEvents {
  * If the command already exists, update its timeout and statusMessage.
  * Otherwise, append it to the matching group (by `matcher`, or the global
  * no-matcher group when `matcher` is omitted) or create one.
- *
- * `statusMessage` is optional: a hook that fires on every tool call (e.g. the
- * PreToolUse approver) should omit it so Codex doesn't flash a status line on
- * unrelated commands.
  */
 function ensureHookRegistered(
   groups: MatcherGroup[],
@@ -232,9 +228,7 @@ function mergeHooksJson(add: boolean) {
     if (!hooks.UserPromptSubmit) hooks.UserPromptSubmit = [];
     ensureHookRegistered(hooks.UserPromptSubmit, recallCmd, RECALL_TIMEOUT_SECONDS, "Searching memories...");
 
-    // Register PreToolUse hook to auto-approve the reasoned-recall search.
-    // Matcher "Bash" scopes it to shell calls; no statusMessage so it stays
-    // silent on every unrelated command (it only acts on the genuine search).
+    // Register PreToolUse hook to auto-approve the reasoned-recall search
     if (!hooks.PreToolUse) hooks.PreToolUse = [];
     ensureHookRegistered(
       hooks.PreToolUse,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -33,10 +33,12 @@ const CODEX_CONFIG_TOML = join(CODEX_DIR, "config.toml");
 const CODEX_HOOKS_JSON = join(CODEX_DIR, "hooks.json");
 const SUPERMEMORY_HOOKS_DIR = join(CODEX_DIR, "supermemory");
 const RECALL_SCRIPT = join(SUPERMEMORY_HOOKS_DIR, "recall.js");
+const RECALL_APPROVE_SCRIPT = join(SUPERMEMORY_HOOKS_DIR, "recall-approve.js");
 const FLUSH_SCRIPT = join(SUPERMEMORY_HOOKS_DIR, "flush.js");
 const SESSION_START_SCRIPT = join(SUPERMEMORY_HOOKS_DIR, "session-start.js");
 const CODEX_SKILLS_DIR = join(homedir(), ".codex", "skills");
 const RECALL_TIMEOUT_SECONDS = 90;
+const RECALL_APPROVE_TIMEOUT_SECONDS = 10;
 const FLUSH_TIMEOUT_SECONDS = 60;
 const SESSION_START_TIMEOUT_SECONDS = 60;
 
@@ -110,6 +112,7 @@ interface MatcherGroup {
 
 interface HookEvents {
   UserPromptSubmit?: MatcherGroup[];
+  PreToolUse?: MatcherGroup[];
   Stop?: MatcherGroup[];
   [key: string]: MatcherGroup[] | undefined;
 }
@@ -130,7 +133,7 @@ function normalizeHookEvents(raw: unknown): HookEvents {
       ? maybeWrapped.hooks
       : (maybeWrapped as HookEvents);
 
-  for (const key of ["UserPromptSubmit", "Stop"] as const) {
+  for (const key of ["UserPromptSubmit", "PreToolUse", "Stop"] as const) {
     const val = events[key];
     if (val !== undefined && !Array.isArray(val)) {
       events[key] = [val as unknown as MatcherGroup];
@@ -143,13 +146,19 @@ function normalizeHookEvents(raw: unknown): HookEvents {
 /**
  * Ensure a hook is registered in the given event's MatcherGroup array.
  * If the command already exists, update its timeout and statusMessage.
- * Otherwise, append it to an existing global (no-matcher) group or create one.
+ * Otherwise, append it to the matching group (by `matcher`, or the global
+ * no-matcher group when `matcher` is omitted) or create one.
+ *
+ * `statusMessage` is optional: a hook that fires on every tool call (e.g. the
+ * PreToolUse approver) should omit it so Codex doesn't flash a status line on
+ * unrelated commands.
  */
 function ensureHookRegistered(
   groups: MatcherGroup[],
   command: string,
   timeout: number,
-  statusMessage: string,
+  statusMessage?: string,
+  matcher?: string,
 ): void {
   const exists = groups.some((g) => g.hooks.some((h) => h.command === command));
   if (exists) {
@@ -157,17 +166,20 @@ function ensureHookRegistered(
       for (const hook of group.hooks) {
         if (hook.command === command) {
           hook.timeout = timeout;
-          hook.statusMessage = statusMessage;
+          if (statusMessage !== undefined) hook.statusMessage = statusMessage;
         }
       }
     }
   } else {
-    const globalGroup = groups.find((g) => !g.matcher);
-    const entry: HookEntry = { type: "command", command, timeout, statusMessage };
-    if (globalGroup) {
-      globalGroup.hooks.push(entry);
+    const targetGroup = matcher
+      ? groups.find((g) => g.matcher === matcher)
+      : groups.find((g) => !g.matcher);
+    const entry: HookEntry = { type: "command", command, timeout };
+    if (statusMessage !== undefined) entry.statusMessage = statusMessage;
+    if (targetGroup) {
+      targetGroup.hooks.push(entry);
     } else {
-      groups.push({ hooks: [entry] });
+      groups.push(matcher ? { matcher, hooks: [entry] } : { hooks: [entry] });
     }
   }
 }
@@ -203,6 +215,7 @@ function mergeHooksJson(add: boolean) {
 
   if (add) {
     const recallCmd = `node ${RECALL_SCRIPT}`;
+    const recallApproveCmd = `node ${RECALL_APPROVE_SCRIPT}`;
     const flushCmd = `node ${FLUSH_SCRIPT}`;
     const sessionStartCmd = `node ${SESSION_START_SCRIPT}`;
     const oldCaptureCmd = `node ${join(SUPERMEMORY_HOOKS_DIR, "capture.js")}`;
@@ -215,9 +228,21 @@ function mergeHooksJson(add: boolean) {
       "Loading memory profile...",
     );
 
-    // Register UserPromptSubmit hook for optional per-prompt recall / turn capture
+    // Register UserPromptSubmit hook for per-turn recall directive / turn capture
     if (!hooks.UserPromptSubmit) hooks.UserPromptSubmit = [];
     ensureHookRegistered(hooks.UserPromptSubmit, recallCmd, RECALL_TIMEOUT_SECONDS, "Searching memories...");
+
+    // Register PreToolUse hook to auto-approve the reasoned-recall search.
+    // Matcher "Bash" scopes it to shell calls; no statusMessage so it stays
+    // silent on every unrelated command (it only acts on the genuine search).
+    if (!hooks.PreToolUse) hooks.PreToolUse = [];
+    ensureHookRegistered(
+      hooks.PreToolUse,
+      recallApproveCmd,
+      RECALL_APPROVE_TIMEOUT_SECONDS,
+      undefined,
+      "Bash",
+    );
 
     // Remove old capture.js Stop hook from previous installs
     if (hooks.Stop) {
@@ -231,6 +256,7 @@ function mergeHooksJson(add: boolean) {
   } else {
     // Remove our hooks from every MatcherGroup, then drop empty groups.
     const recallCmd = `node ${RECALL_SCRIPT}`;
+    const recallApproveCmd = `node ${RECALL_APPROVE_SCRIPT}`;
     const flushCmd = `node ${FLUSH_SCRIPT}`;
     const sessionStartCmd = `node ${SESSION_START_SCRIPT}`;
     const oldCaptureCmd = `node ${join(SUPERMEMORY_HOOKS_DIR, "capture.js")}`;
@@ -242,6 +268,10 @@ function mergeHooksJson(add: boolean) {
     if (hooks.UserPromptSubmit) {
       hooks.UserPromptSubmit = removeHookCommands(hooks.UserPromptSubmit, [recallCmd]);
       if (hooks.UserPromptSubmit.length === 0) delete hooks.UserPromptSubmit;
+    }
+    if (hooks.PreToolUse) {
+      hooks.PreToolUse = removeHookCommands(hooks.PreToolUse, [recallApproveCmd]);
+      if (hooks.PreToolUse.length === 0) delete hooks.PreToolUse;
     }
     if (hooks.Stop) {
       hooks.Stop = removeHookCommands(hooks.Stop, [flushCmd, oldCaptureCmd]);
@@ -262,15 +292,22 @@ function install() {
 
   // Copy hook scripts
   const recallSrc = join(DIST_HOOKS_DIR, "recall.js");
+  const recallApproveSrc = join(DIST_HOOKS_DIR, "recall-approve.js");
   const flushSrc = join(DIST_HOOKS_DIR, "flush.js");
   const sessionStartSrc = join(DIST_HOOKS_DIR, "session-start.js");
 
-  if (!existsSync(recallSrc) || !existsSync(flushSrc) || !existsSync(sessionStartSrc)) {
+  if (
+    !existsSync(recallSrc) ||
+    !existsSync(recallApproveSrc) ||
+    !existsSync(flushSrc) ||
+    !existsSync(sessionStartSrc)
+  ) {
     console.error("Error: Hook scripts not found. Please reinstall the package.");
     process.exit(1);
   }
 
   copyFileSync(recallSrc, RECALL_SCRIPT);
+  copyFileSync(recallApproveSrc, RECALL_APPROVE_SCRIPT);
   copyFileSync(flushSrc, FLUSH_SCRIPT);
   copyFileSync(sessionStartSrc, SESSION_START_SCRIPT);
 
@@ -368,6 +405,7 @@ function status() {
 
   const hooksInstalled =
     existsSync(RECALL_SCRIPT) &&
+    existsSync(RECALL_APPROVE_SCRIPT) &&
     existsSync(FLUSH_SCRIPT) &&
     existsSync(SESSION_START_SCRIPT);
   const hooksJsonExists = existsSync(CODEX_HOOKS_JSON);
@@ -378,10 +416,14 @@ function status() {
     try {
       const hooks = normalizeHookEvents(JSON.parse(readFileSync(CODEX_HOOKS_JSON, "utf-8")));
       const recallCmd = `node ${RECALL_SCRIPT}`;
+      const recallApproveCmd = `node ${RECALL_APPROVE_SCRIPT}`;
       const flushCmd = `node ${FLUSH_SCRIPT}`;
       const sessionStartCmd = `node ${SESSION_START_SCRIPT}`;
       const recallRegistered = hooks.UserPromptSubmit?.some((g: MatcherGroup) =>
         g.hooks.some((h: HookEntry) => h.command === recallCmd)
+      );
+      const recallApproveRegistered = hooks.PreToolUse?.some((g: MatcherGroup) =>
+        g.hooks.some((h: HookEntry) => h.command === recallApproveCmd)
       );
       const flushRegistered = hooks.Stop?.some((g: MatcherGroup) =>
         g.hooks.some((h: HookEntry) => h.command === flushCmd)
@@ -389,7 +431,12 @@ function status() {
       const sessionStartRegistered = hooks.SessionStart?.some((g: MatcherGroup) =>
         g.hooks.some((h: HookEntry) => h.command === sessionStartCmd)
       );
-      hooksEnabled = !!(recallRegistered && flushRegistered && sessionStartRegistered);
+      hooksEnabled = !!(
+        recallRegistered &&
+        recallApproveRegistered &&
+        flushRegistered &&
+        sessionStartRegistered
+      );
     } catch {
       // ignore
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,7 @@ import { homedir } from "node:os";
 import { loadCredentialData, loadCredentials } from "./services/auth.js";
 
 export const CONFIG_FILE = join(homedir(), ".codex", "supermemory.json");
-export const PLUGIN_VERSION = "1.0.8";
+export const PLUGIN_VERSION = "1.0.9";
 export const DEFAULT_BASE_URL = "https://api.supermemory.ai";
 
 export interface CustomContainer {

--- a/src/config.ts
+++ b/src/config.ts
@@ -256,17 +256,6 @@ export function getRecallModeSummary(): string {
   return "reasoned: session-start profile + per-turn reasoned recall + session-end flush";
 }
 
-/**
- * Resolve the reasoned-recall directive override.
- *
- * Reasoned recall is always on — a built-in optimization, not a toggle. The
- * only knob is an optional override of the injected directive text via
- * `recallDirective` in ~/.codex/supermemory.json; a null/absent value tells the
- * recall hook to fall back to its built-in DEFAULT_RECALL_DIRECTIVE.
- *
- * `cwd` is accepted for forward-compatibility with per-project overrides but is
- * currently unused — Codex has no per-project supermemory config.
- */
 export function getRecallConfig(_cwd?: string): { directive: string | null } {
   return { directive: CONFIG.recallDirective ?? null };
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -31,6 +31,7 @@ interface CodexSupermemoryConfig {
   autoSaveEveryTurns?: number;
   autoRecallEveryPrompt?: boolean;
   captureEveryNTurns?: number;
+  recallDirective?: string | null;
   enableCustomContainers?: boolean;
   customContainers?: CustomContainer[];
   customContainerInstructions?: string;
@@ -118,6 +119,7 @@ export const CONFIG = {
   autoSaveEveryTurns: fileConfig.autoSaveEveryTurns ?? DEFAULTS.autoSaveEveryTurns,
   autoRecallEveryPrompt: resolveAutoRecallEveryPrompt(fileConfig),
   captureEveryNTurns: resolveCaptureEveryNTurns(fileConfig),
+  recallDirective: fileConfig.recallDirective ?? null,
   enableCustomContainers: fileConfig.enableCustomContainers ?? false,
   customContainers: (fileConfig.customContainers ?? []).filter(
     (c): c is CustomContainer =>
@@ -246,10 +248,25 @@ export function writeInstallDefaults(isExistingInstall: boolean): void {
 
 export function getRecallModeSummary(): string {
   if (CONFIG.autoRecallEveryPrompt) {
-    return "legacy: recall on every prompt";
+    return "legacy: eager search on every prompt";
   }
   if (CONFIG.captureEveryNTurns > 0) {
-    return `unified: session-start profile + capture every ${CONFIG.captureEveryNTurns} turns + session-end flush`;
+    return `reasoned: session-start profile + per-turn reasoned recall + capture every ${CONFIG.captureEveryNTurns} turns + session-end flush`;
   }
-  return "unified: session-start profile + session-end flush only";
+  return "reasoned: session-start profile + per-turn reasoned recall + session-end flush";
+}
+
+/**
+ * Resolve the reasoned-recall directive override.
+ *
+ * Reasoned recall is always on — a built-in optimization, not a toggle. The
+ * only knob is an optional override of the injected directive text via
+ * `recallDirective` in ~/.codex/supermemory.json; a null/absent value tells the
+ * recall hook to fall back to its built-in DEFAULT_RECALL_DIRECTIVE.
+ *
+ * `cwd` is accepted for forward-compatibility with per-project overrides but is
+ * currently unused — Codex has no per-project supermemory config.
+ */
+export function getRecallConfig(_cwd?: string): { directive: string | null } {
+  return { directive: CONFIG.recallDirective ?? null };
 }

--- a/src/hooks/recall-approve.ts
+++ b/src/hooks/recall-approve.ts
@@ -1,34 +1,8 @@
 import { readFileSync } from "node:fs";
 import { log } from "../services/logger.js";
 
-// ---------------------------------------------------------------------------
-// Auto-approve reasoned recall (PreToolUse).
-//
-// Reasoned recall is decided by the model, but it runs through the
-// supermemory-search skill — a shell (Bash) tool call, which would normally
-// trigger a permission prompt. The capture/flush path runs silently; recall
-// should feel the same.
-//
-// This PreToolUse hook returns `permissionDecision: "allow"` ONLY for a clean
-// `node … search-memory.js` invocation. Every other command — and any search
-// command laced with shell chaining/redirection — falls through to Codex's
-// normal permission flow untouched (we emit nothing). We never deny: denying is
-// what would break a user's legitimate command, so on anything unexpected we
-// stay out of the way.
-//
-// The hook is registered with the "Bash" matcher, so Codex only invokes it for
-// shell calls; we re-assert tool_name === "Bash" here as defense-in-depth, and
-// the command checks below are the real security gate.
-// ---------------------------------------------------------------------------
-
-// Codex's canonical shell tool name (and the registered PreToolUse matcher).
 const SHELL_TOOL_NAME = "Bash";
-
-// Matches a Bash command that actually *runs* the search script (a `node`
-// invocation ahead of the script), not e.g. `rm search-memory.js`.
 const SEARCH_BASH_RE = /node[\s\S]*search-memory\.js/;
-// Refuse to auto-approve if the command chains/redirects to anything else, so a
-// laced command like `node …search-memory.js; rm -rf ~` still prompts.
 const SHELL_OPS = /[;&|`>]|\$\(/;
 
 interface CodexPreToolUsePayload {
@@ -52,7 +26,6 @@ function main(): void {
   try {
     rawInput = readFileSync(0, "utf-8");
   } catch {
-    // No stdin — nothing to approve. Let Codex's normal flow proceed.
     process.exit(0);
   }
 
@@ -79,11 +52,9 @@ function main(): void {
       process.exit(0);
     }
   } catch (error) {
-    // Fail open — never block a tool call because our approve hook errored.
     log("recall-approve: error", { error: String(error) });
   }
 
-  // Not our search (or an error above): stay out of Codex's permission flow.
   process.exit(0);
 }
 

--- a/src/hooks/recall-approve.ts
+++ b/src/hooks/recall-approve.ts
@@ -1,0 +1,90 @@
+import { readFileSync } from "node:fs";
+import { log } from "../services/logger.js";
+
+// ---------------------------------------------------------------------------
+// Auto-approve reasoned recall (PreToolUse).
+//
+// Reasoned recall is decided by the model, but it runs through the
+// supermemory-search skill — a shell (Bash) tool call, which would normally
+// trigger a permission prompt. The capture/flush path runs silently; recall
+// should feel the same.
+//
+// This PreToolUse hook returns `permissionDecision: "allow"` ONLY for a clean
+// `node … search-memory.js` invocation. Every other command — and any search
+// command laced with shell chaining/redirection — falls through to Codex's
+// normal permission flow untouched (we emit nothing). We never deny: denying is
+// what would break a user's legitimate command, so on anything unexpected we
+// stay out of the way.
+//
+// The hook is registered with the "Bash" matcher, so Codex only invokes it for
+// shell calls; we re-assert tool_name === "Bash" here as defense-in-depth, and
+// the command checks below are the real security gate.
+// ---------------------------------------------------------------------------
+
+// Codex's canonical shell tool name (and the registered PreToolUse matcher).
+const SHELL_TOOL_NAME = "Bash";
+
+// Matches a Bash command that actually *runs* the search script (a `node`
+// invocation ahead of the script), not e.g. `rm search-memory.js`.
+const SEARCH_BASH_RE = /node[\s\S]*search-memory\.js/;
+// Refuse to auto-approve if the command chains/redirects to anything else, so a
+// laced command like `node …search-memory.js; rm -rf ~` still prompts.
+const SHELL_OPS = /[;&|`>]|\$\(/;
+
+interface CodexPreToolUsePayload {
+  tool_name?: string;
+  tool_input?: { command?: unknown } | null;
+  [key: string]: unknown;
+}
+
+function isSupermemorySearch(
+  toolName: string | undefined,
+  toolInput: CodexPreToolUsePayload["tool_input"],
+): boolean {
+  if (toolName !== SHELL_TOOL_NAME) return false;
+  const command = String(toolInput?.command ?? "");
+  if (!command) return false;
+  return SEARCH_BASH_RE.test(command) && !SHELL_OPS.test(command);
+}
+
+function main(): void {
+  let rawInput = "";
+  try {
+    rawInput = readFileSync(0, "utf-8");
+  } catch {
+    // No stdin — nothing to approve. Let Codex's normal flow proceed.
+    process.exit(0);
+  }
+
+  let payload: CodexPreToolUsePayload = {};
+  try {
+    payload = JSON.parse(rawInput) as CodexPreToolUsePayload;
+  } catch {
+    process.exit(0);
+  }
+
+  try {
+    if (isSupermemorySearch(payload.tool_name, payload.tool_input)) {
+      log("recall-approve: auto-approving search", { toolName: payload.tool_name });
+      process.stdout.write(
+        JSON.stringify({
+          hookSpecificOutput: {
+            hookEventName: "PreToolUse",
+            permissionDecision: "allow",
+            permissionDecisionReason:
+              "Supermemory reasoned recall runs automatically (read-only memory search).",
+          },
+        })
+      );
+      process.exit(0);
+    }
+  } catch (error) {
+    // Fail open — never block a tool call because our approve hook errored.
+    log("recall-approve: error", { error: String(error) });
+  }
+
+  // Not our search (or an error above): stay out of Codex's permission flow.
+  process.exit(0);
+}
+
+main();

--- a/src/hooks/recall.ts
+++ b/src/hooks/recall.ts
@@ -1,7 +1,7 @@
 import { readFileSync, existsSync, writeFileSync, unlinkSync, mkdirSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { homedir } from "node:os";
-import { isConfigured, CONFIG, reloadApiKey, getContainerCatalog } from "../config.js";
+import { isConfigured, CONFIG, reloadApiKey, getContainerCatalog, getRecallConfig } from "../config.js";
 import { SupermemoryClient } from "../services/client.js";
 import { getTags } from "../services/tags.js";
 import { formatCombinedContext } from "../services/context.js";
@@ -13,6 +13,40 @@ import { getSessionId } from "../services/session.js";
 
 const AUTH_ATTEMPTED_FILE = join(homedir(), ".codex", "supermemory", ".auth-attempted");
 const LOGGED_OUT_FILE = join(homedir(), ".codex", "supermemory", ".logged-out");
+
+// ---------------------------------------------------------------------------
+// Reasoned recall directive.
+//
+// Injected before every user turn (in the default, non-eager mode) so the model
+// REASONS about whether recalling saved memory would help THIS message, instead
+// of the hook eagerly searching on every prompt. The decision is the model's,
+// per message; this hook only delivers the directive (no network call here).
+//
+// Edit this text to tune behavior, or override it globally via the
+// `recallDirective` setting in ~/.codex/supermemory.json.
+// ---------------------------------------------------------------------------
+const DEFAULT_RECALL_DIRECTIVE = `<supermemory-recall>
+Before responding, silently decide whether recalling saved memory (past sessions, decisions, conventions, the user's preferences) would materially improve your answer to THIS message. Reason first — don't search reflexively, and don't narrate the decision.
+
+Recall — via the supermemory-search skill — when the message:
+- refers to earlier work or decisions ("the auth flow", "like we did", "continue", "the bug from before")
+- touches an area where saved conventions, patterns, or preferences likely exist
+- is ambiguous in a way past context would resolve
+
+Skip recall when the message is self-contained, trivial, a greeting/meta, fully answerable from the current conversation, or you already recalled the relevant context this session and the topic hasn't shifted.
+
+Cadence is per-message: it's fine to recall on several turns in a row, and fine to never recall in a session. When you do recall, run it before answering and fold the results into your response.
+</supermemory-recall>`;
+
+// Appended to the directive only when debug is on. Forces the model to surface
+// its recall decision as one visible line, so you can see — per turn — whether
+// reasoned recall fired and why. (The hook can't observe the model's internal
+// decision; this makes the model report it.)
+const RECALL_DEBUG_SUFFIX = `<recall-debug>
+DEBUG MODE: Begin your reply with exactly one line, then continue normally:
+[recall-decision] yes|no — <short reason>
+"yes" means you are recalling saved Supermemory memory (via the supermemory-search skill) for THIS message; "no" means you are skipping it.
+</recall-debug>`;
 
 interface CodexHookPayload {
   session_id?: string;
@@ -119,7 +153,27 @@ async function main() {
   }
 
   if (!CONFIG.autoRecallEveryPrompt) {
-    exitWithContext("");
+    // Reasoned mode (default): don't search in the hook. Inject the recall
+    // directive so the model decides per-turn whether to call the
+    // supermemory-search skill (auto-approved by the PreToolUse hook).
+    const { directive } = getRecallConfig(cwd);
+    let additionalContext = directive || DEFAULT_RECALL_DIRECTIVE;
+    const debugDecision = !!(CONFIG.debug || process.env.SUPERMEMORY_DEBUG);
+    if (debugDecision) {
+      additionalContext += `\n\n${RECALL_DEBUG_SUFFIX}`;
+    }
+
+    const containerCatalog = getContainerCatalog();
+    if (containerCatalog) {
+      additionalContext += `\n\n[SUPERMEMORY CONTAINERS]\n${containerCatalog}\n[END SUPERMEMORY CONTAINERS]`;
+    }
+
+    log("recall: inject directive", {
+      custom: !!directive,
+      debugDecision,
+      additionalContextLength: additionalContext.length,
+    });
+    exitWithContext(additionalContext);
   }
 
   try {

--- a/src/hooks/recall.ts
+++ b/src/hooks/recall.ts
@@ -14,17 +14,6 @@ import { getSessionId } from "../services/session.js";
 const AUTH_ATTEMPTED_FILE = join(homedir(), ".codex", "supermemory", ".auth-attempted");
 const LOGGED_OUT_FILE = join(homedir(), ".codex", "supermemory", ".logged-out");
 
-// ---------------------------------------------------------------------------
-// Reasoned recall directive.
-//
-// Injected before every user turn (in the default, non-eager mode) so the model
-// REASONS about whether recalling saved memory would help THIS message, instead
-// of the hook eagerly searching on every prompt. The decision is the model's,
-// per message; this hook only delivers the directive (no network call here).
-//
-// Edit this text to tune behavior, or override it globally via the
-// `recallDirective` setting in ~/.codex/supermemory.json.
-// ---------------------------------------------------------------------------
 const DEFAULT_RECALL_DIRECTIVE = `<supermemory-recall>
 Before responding, silently decide whether recalling saved memory (past sessions, decisions, conventions, the user's preferences) would materially improve your answer to THIS message. Reason first — don't search reflexively, and don't narrate the decision.
 
@@ -38,10 +27,6 @@ Skip recall when the message is self-contained, trivial, a greeting/meta, fully 
 Cadence is per-message: it's fine to recall on several turns in a row, and fine to never recall in a session. When you do recall, run it before answering and fold the results into your response.
 </supermemory-recall>`;
 
-// Appended to the directive only when debug is on. Forces the model to surface
-// its recall decision as one visible line, so you can see — per turn — whether
-// reasoned recall fired and why. (The hook can't observe the model's internal
-// decision; this makes the model report it.)
 const RECALL_DEBUG_SUFFIX = `<recall-debug>
 DEBUG MODE: Begin your reply with exactly one line, then continue normally:
 [recall-decision] yes|no — <short reason>
@@ -153,9 +138,6 @@ async function main() {
   }
 
   if (!CONFIG.autoRecallEveryPrompt) {
-    // Reasoned mode (default): don't search in the hook. Inject the recall
-    // directive so the model decides per-turn whether to call the
-    // supermemory-search skill (auto-approved by the PreToolUse hook).
     const { directive } = getRecallConfig(cwd);
     let additionalContext = directive || DEFAULT_RECALL_DIRECTIVE;
     const debugDecision = !!(CONFIG.debug || process.env.SUPERMEMORY_DEBUG);

--- a/test/unit.mjs
+++ b/test/unit.mjs
@@ -414,6 +414,57 @@ describe("integration: install/uninstall", () => {
     const config = readToml(configPath);
     assert.ok(!config.features, "features table should not exist after uninstall");
   });
+
+  test("install registers the PreToolUse recall-approve hook (matcher Bash, silent)", (t) => {
+    const { tmpDir, codexDir } = setupCodexHome(t);
+
+    const result = runCli(cliBin, "install", tmpDir);
+    assert.equal(result.status, 0, `install should exit 0: ${result.stderr}`);
+
+    const hooksJson = JSON.parse(readFileSync(join(codexDir, "hooks.json"), "utf-8"));
+    const pre = hooksJson.hooks.PreToolUse;
+    assert.ok(Array.isArray(pre), "hooks.PreToolUse must be an array");
+    const group = pre.find((g) => g.matcher === "Bash");
+    assert.ok(group, "a PreToolUse group with matcher 'Bash' should exist");
+    const entry = group.hooks.find((h) => h.command.includes("recall-approve.js"));
+    assert.ok(entry, "recall-approve.js should be registered under PreToolUse");
+    assert.equal(entry.timeout, 10);
+    assert.ok(
+      !("statusMessage" in entry),
+      "approve hook should have no statusMessage (it fires on every Bash call)"
+    );
+    assert.ok(
+      existsSync(join(codexDir, "supermemory", "recall-approve.js")),
+      "recall-approve.js script should be installed"
+    );
+  });
+
+  test("install is idempotent for the PreToolUse hook (no duplicate entries)", (t) => {
+    const { tmpDir, codexDir } = setupCodexHome(t);
+
+    assert.equal(runCli(cliBin, "install", tmpDir).status, 0);
+    assert.equal(runCli(cliBin, "install", tmpDir).status, 0);
+
+    const hooksJson = JSON.parse(readFileSync(join(codexDir, "hooks.json"), "utf-8"));
+    const entries = (hooksJson.hooks.PreToolUse || [])
+      .flatMap((g) => g.hooks)
+      .filter((h) => h.command.includes("recall-approve.js"));
+    assert.equal(entries.length, 1, "exactly one recall-approve entry after two installs");
+  });
+
+  test("uninstall removes the PreToolUse recall-approve hook", (t) => {
+    const { tmpDir, codexDir } = setupCodexHome(t);
+
+    assert.equal(runCli(cliBin, "install", tmpDir).status, 0);
+    assert.equal(runCli(cliBin, "uninstall", tmpDir).status, 0);
+
+    const hooksJson = JSON.parse(readFileSync(join(codexDir, "hooks.json"), "utf-8"));
+    assert.ok(!hooksJson.hooks.PreToolUse, "PreToolUse event should be removed on uninstall");
+    assert.ok(
+      !existsSync(join(codexDir, "supermemory", "recall-approve.js")),
+      "recall-approve.js script should be removed"
+    );
+  });
 });
 
 
@@ -484,6 +535,37 @@ describe("recall hook output envelope", () => {
     assert.equal(result.stdout, "");
   });
 
+  test("injects the reasoned recall directive when configured (default mode)", (t) => {
+    // No config file under this HOME -> autoRecallEveryPrompt defaults to false
+    // (reasoned mode) and captureEveryNTurns defaults to 0, so the hook injects
+    // the directive without any network call.
+    const tmpDir = makeTmpDir();
+    mkdirSync(join(tmpDir, ".codex", "supermemory"), { recursive: true });
+    t.after(() => rmSync(tmpDir, { recursive: true, force: true }));
+
+    const result = spawnSync("node", [recallBin], {
+      input: JSON.stringify({ session_id: "s1", prompt: "continue the auth refactor", cwd: tmpDir }),
+      env: {
+        ...process.env,
+        HOME: tmpDir,
+        USERPROFILE: tmpDir,
+        SUPERMEMORY_CODEX_API_KEY: "sm_test",
+        SUPERMEMORY_DEBUG: "",
+      },
+      encoding: "utf-8",
+      timeout: 5_000,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    const parsed = JSON.parse(result.stdout);
+    assert.equal(parsed.hookSpecificOutput.hookEventName, "UserPromptSubmit");
+    assert.match(
+      parsed.hookSpecificOutput.additionalContext,
+      /<supermemory-recall>/,
+      "should inject the reasoned recall directive"
+    );
+  });
+
   test("never outputs bare additionalContext at top level (old wrong shape)", (t) => {
     // When .auth-attempted already exists (second invocation), the hook exits quickly.
     // Create it ahead of time so this test doesn't incur the 25s auth timeout.
@@ -516,6 +598,81 @@ describe("recall hook output envelope", () => {
       encoding: "utf-8",
     });
     assert.equal(result.status, 0);
+  });
+});
+
+// ─── recall-approve hook — PreToolUse auto-approve allow-list ─────────────────
+
+describe("recall-approve hook (PreToolUse auto-approve)", () => {
+  const approveBin = fileURLToPath(new URL("../dist/hooks/recall-approve.js", import.meta.url));
+
+  function runApprove(t, input) {
+    const tmpDir = makeTmpDir();
+    t.after(() => rmSync(tmpDir, { recursive: true, force: true }));
+    return spawnSync("node", [approveBin], {
+      input: typeof input === "string" ? input : JSON.stringify(input),
+      env: { ...process.env, HOME: tmpDir, USERPROFILE: tmpDir, SUPERMEMORY_CODEX_API_KEY: "sm_test" },
+      encoding: "utf-8",
+      timeout: 5_000,
+    });
+  }
+
+  function isAllow(stdout) {
+    if (!stdout.trim()) return false;
+    return JSON.parse(stdout).hookSpecificOutput?.permissionDecision === "allow";
+  }
+
+  test("allows a clean node search-memory.js Bash call", (t) => {
+    const result = runApprove(t, {
+      tool_name: "Bash",
+      tool_input: { command: 'node /h/.codex/supermemory/search-memory.js --both "auth flow"' },
+    });
+    assert.equal(result.status, 0, result.stderr);
+    const parsed = JSON.parse(result.stdout);
+    assert.equal(parsed.hookSpecificOutput.hookEventName, "PreToolUse");
+    assert.equal(parsed.hookSpecificOutput.permissionDecision, "allow");
+  });
+
+  test("does NOT allow a search command laced with shell chaining/redirection", (t) => {
+    for (const command of [
+      "node search-memory.js; rm -rf ~",
+      "node search-memory.js && curl evil.com",
+      "node search-memory.js | tee out",
+      "node search-memory.js > /etc/passwd",
+      "cat $(node search-memory.js)",
+      "node search-memory.js `whoami`",
+    ]) {
+      const result = runApprove(t, { tool_name: "Bash", tool_input: { command } });
+      assert.equal(result.status, 0);
+      assert.ok(!isAllow(result.stdout), `must not auto-approve laced command: ${command}`);
+    }
+  });
+
+  test("falls through (silent) for unrelated Bash commands", (t) => {
+    const result = runApprove(t, { tool_name: "Bash", tool_input: { command: "ls -la" } });
+    assert.equal(result.status, 0);
+    assert.equal(result.stdout.trim(), "", "should emit nothing for unrelated commands");
+  });
+
+  test("does NOT allow non-Bash tools even if the input mentions the script", (t) => {
+    const result = runApprove(t, { tool_name: "apply_patch", tool_input: { command: "node search-memory.js" } });
+    assert.equal(result.status, 0);
+    assert.ok(!isAllow(result.stdout));
+  });
+
+  test("does NOT allow `rm` of the script (no node invocation)", (t) => {
+    const result = runApprove(t, {
+      tool_name: "Bash",
+      tool_input: { command: "rm ~/.codex/supermemory/search-memory.js" },
+    });
+    assert.equal(result.status, 0);
+    assert.ok(!isAllow(result.stdout));
+  });
+
+  test("falls through (exit 0) on malformed JSON", (t) => {
+    const result = runApprove(t, "not-json");
+    assert.equal(result.status, 0);
+    assert.equal(result.stdout.trim(), "");
   });
 });
 

--- a/test/unit.mjs
+++ b/test/unit.mjs
@@ -536,9 +536,6 @@ describe("recall hook output envelope", () => {
   });
 
   test("injects the reasoned recall directive when configured (default mode)", (t) => {
-    // No config file under this HOME -> autoRecallEveryPrompt defaults to false
-    // (reasoned mode) and captureEveryNTurns defaults to 0, so the hook injects
-    // the directive without any network call.
     const tmpDir = makeTmpDir();
     mkdirSync(join(tmpDir, ".codex", "supermemory"), { recursive: true });
     t.after(() => rmSync(tmpDir, { recursive: true, force: true }));


### PR DESCRIPTION
## What

Ports the Claude Code **"reasoned per-turn memory recall with auto-approve"** feature to the Codex plugin. Instead of eagerly searching on every prompt, the model now decides _per message_ whether recalling saved memory would help — and the resulting search is auto-approved so it stays silent, just like the capture/save path.

## How it works — 3 parts

1. **Directive injection** (`src/hooks/recall.ts`) — in the default (non-eager) mode the `UserPromptSubmit` hook injects a directive so the model reasons per turn about whether to call the `supermemory-search` skill. Legacy `autoRecallEveryPrompt` eager search is unchanged.
2. **Auto-approve** (`src/hooks/recall-approve.ts`, new) — a `PreToolUse` hook (matcher `Bash`) returns `permissionDecision: "allow"` **only** for a clean `node … search-memory.js` call with no shell chaining/redirection. Everything else falls through to Codex's normal approval flow; the hook never denies and fails open.
3. **Config** (`src/config.ts`) — adds a global `recallDirective` override + `getRecallConfig()`. `cli.ts` registers/unregisters the new hook and reports it in `status`.

## Codex-specific notes

- Confirmed against the [official Codex hooks docs](https://developers.openai.com/codex/hooks) that `PreToolUse` + `permissionDecision: "allow"` auto-approves the `Bash` tool — which is exactly how the `supermemory-search` skill runs.
- Deviations from the Claude Code version: `.cjs`→`.js`, matcher `Skill|Bash`→`Bash`, silent fall-through (emit nothing, matching existing Codex hooks), global-only config (no per-project override).

## Test plan

- `npm test` → **61/61 pass** (build + typecheck clean).
- New coverage: `PreToolUse` registration / idempotency / uninstall, directive injection in reasoned mode, and the approve allow-list (genuine search allowed; shell-laced, unrelated, and non-`Bash` calls fall through).

🤖 Generated with [Claude Code](https://claude.com/claude-code)