### PR TITLE
Add Codex auto OAuth prompt

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -12,6 +12,7 @@ const sharedConfig = {
 
 const executableEntries = [
   { in: "src/cli.ts", out: "dist/cli.js" },
+  { in: "src/auth-background.ts", out: "dist/hooks/auth-background.js" },
   ...["recall", "flush", "session-start"].map((n) => ({
     in: `src/hooks/${n}.ts`,
     out: `dist/hooks/${n}.js`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-supermemory",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-supermemory",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-supermemory",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Persistent memory for OpenAI Codex CLI — powered by Supermemory",
   "type": "module",
   "main": "dist/cli.js",

--- a/src/auth-background.ts
+++ b/src/auth-background.ts
@@ -1,0 +1,24 @@
+import { existsSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { createAuthSession } from "./services/auth.js";
+import { openUrl } from "./services/openUrl.js";
+import { log } from "./services/logger.js";
+
+const AUTH_ATTEMPTED_FILE = join(homedir(), ".codex", "supermemory", ".auth-attempted");
+
+async function main(): Promise<void> {
+  try {
+    const session = await createAuthSession();
+    await openUrl(session.authUrl);
+    await session.callback();
+    try {
+      if (existsSync(AUTH_ATTEMPTED_FILE)) unlinkSync(AUTH_ATTEMPTED_FILE);
+    } catch {}
+    log("auth-background: completed");
+  } catch (error) {
+    log("auth-background: failed", { error: String(error) });
+  }
+}
+
+main().catch(() => {});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -35,6 +35,7 @@ const SUPERMEMORY_HOOKS_DIR = join(CODEX_DIR, "supermemory");
 const RECALL_SCRIPT = join(SUPERMEMORY_HOOKS_DIR, "recall.js");
 const FLUSH_SCRIPT = join(SUPERMEMORY_HOOKS_DIR, "flush.js");
 const SESSION_START_SCRIPT = join(SUPERMEMORY_HOOKS_DIR, "session-start.js");
+const AUTH_BACKGROUND_SCRIPT = join(SUPERMEMORY_HOOKS_DIR, "auth-background.js");
 const CODEX_SKILLS_DIR = join(homedir(), ".codex", "skills");
 const RECALL_TIMEOUT_SECONDS = 90;
 const FLUSH_TIMEOUT_SECONDS = 60;
@@ -264,8 +265,9 @@ function install() {
   const recallSrc = join(DIST_HOOKS_DIR, "recall.js");
   const flushSrc = join(DIST_HOOKS_DIR, "flush.js");
   const sessionStartSrc = join(DIST_HOOKS_DIR, "session-start.js");
+  const authBackgroundSrc = join(DIST_HOOKS_DIR, "auth-background.js");
 
-  if (!existsSync(recallSrc) || !existsSync(flushSrc) || !existsSync(sessionStartSrc)) {
+  if (!existsSync(recallSrc) || !existsSync(flushSrc) || !existsSync(sessionStartSrc) || !existsSync(authBackgroundSrc)) {
     console.error("Error: Hook scripts not found. Please reinstall the package.");
     process.exit(1);
   }
@@ -273,6 +275,7 @@ function install() {
   copyFileSync(recallSrc, RECALL_SCRIPT);
   copyFileSync(flushSrc, FLUSH_SCRIPT);
   copyFileSync(sessionStartSrc, SESSION_START_SCRIPT);
+  copyFileSync(authBackgroundSrc, AUTH_BACKGROUND_SCRIPT);
 
   // Remove script names left by older package layouts.
   for (const script of LEGACY_SUPERMEMORY_SCRIPTS) {

--- a/src/hooks/recall.ts
+++ b/src/hooks/recall.ts
@@ -1,18 +1,38 @@
-import { readFileSync, existsSync, writeFileSync, unlinkSync, mkdirSync } from "node:fs";
+import { readFileSync, existsSync, writeFileSync, mkdirSync, statSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { homedir } from "node:os";
-import { isConfigured, CONFIG, reloadApiKey, getContainerCatalog } from "../config.js";
+import { spawn } from "node:child_process";
+import { isConfigured, CONFIG, getContainerCatalog } from "../config.js";
 import { SupermemoryClient } from "../services/client.js";
 import { getTags } from "../services/tags.js";
 import { formatCombinedContext } from "../services/context.js";
 import { log } from "../services/logger.js";
-import { startAuthFlow, AUTH_BASE_URL } from "../services/auth.js";
 import { captureEntries, resolveTranscriptPath } from "../services/capture.js";
 import { getSeenFacts, addSeenFacts } from "../services/factCache.js";
 import { getSessionId } from "../services/session.js";
 
 const AUTH_ATTEMPTED_FILE = join(homedir(), ".codex", "supermemory", ".auth-attempted");
+const AUTH_RETRY_MS = 10 * 60_000;
 const LOGGED_OUT_FILE = join(homedir(), ".codex", "supermemory", ".logged-out");
+
+function hasRecentAuthAttempt(): boolean {
+  try {
+    return Date.now() - statSync(AUTH_ATTEMPTED_FILE).mtimeMs < AUTH_RETRY_MS;
+  } catch {
+    return false;
+  }
+}
+
+function startAuthBackground(): void {
+  const hookDir = dirname(process.argv[1] || "");
+  const script = join(hookDir, "auth-background.js");
+  const child = spawn(process.execPath, [script], {
+    detached: true,
+    stdio: "ignore",
+    windowsHide: true,
+  });
+  child.unref();
+}
 
 interface CodexHookPayload {
   session_id?: string;
@@ -51,38 +71,23 @@ async function main() {
       exitWithContext("");
     }
 
-    const alreadyAttempted = existsSync(AUTH_ATTEMPTED_FILE);
-
-    if (!alreadyAttempted) {
+    if (!hasRecentAuthAttempt()) {
       try {
         mkdirSync(dirname(AUTH_ATTEMPTED_FILE), { recursive: true });
         writeFileSync(AUTH_ATTEMPTED_FILE, new Date().toISOString());
       } catch {}
-
-      try {
-        log("recall: no API key, starting browser auth flow");
-        await startAuthFlow();
-        reloadApiKey();
-        try { unlinkSync(AUTH_ATTEMPTED_FILE); } catch {}
-        log("recall: auth flow completed");
-      } catch (authErr) {
-        const isTimeout =
-          authErr instanceof Error && authErr.message === "AUTH_TIMEOUT";
-        exitWithContext(
-          "[SUPERMEMORY] Memory is installed but NOT active — missing API key.\n" +
-          (isTimeout
-            ? "Authentication timed out. Please complete login in the browser.\n"
-            : "Authentication failed.\n") +
-          `If the browser did not open, visit: ${AUTH_BASE_URL}\n` +
-          "Run /supermemory-login to try again, or set SUPERMEMORY_CODEX_API_KEY manually."
-        );
-      }
-    } else {
+      log("recall: no API key, starting background browser auth flow");
+      startAuthBackground();
       exitWithContext(
-        "[SUPERMEMORY] Memory is installed but NOT active — missing API key.\n" +
-        "Run /supermemory-login to authenticate, or set SUPERMEMORY_CODEX_API_KEY in your shell profile."
+        "[SUPERMEMORY] Memory is installed but not connected. I opened the login page in your browser. " +
+        "Complete login there, then continue in Codex. You can also run /supermemory-login manually."
       );
     }
+
+    exitWithContext(
+      "[SUPERMEMORY] Memory is installed but not connected. A login page was opened recently. " +
+      "Complete login there, or run /supermemory-login to authenticate."
+    );
   }
 
   let payload: CodexHookPayload = {};

--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -1,17 +1,37 @@
-import { readFileSync, existsSync, writeFileSync, unlinkSync, mkdirSync } from "node:fs";
+import { readFileSync, existsSync, writeFileSync, mkdirSync, statSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { homedir } from "node:os";
-import { isConfigured, CONFIG, PLUGIN_VERSION, reloadApiKey } from "../config.js";
+import { spawn } from "node:child_process";
+import { isConfigured, CONFIG, PLUGIN_VERSION } from "../config.js";
 import { SupermemoryClient } from "../services/client.js";
 import { getTags } from "../services/tags.js";
 import { formatCombinedContext } from "../services/context.js";
 import { log } from "../services/logger.js";
-import { startAuthFlow, AUTH_BASE_URL } from "../services/auth.js";
 import { getSeenFacts, addSeenFacts } from "../services/factCache.js";
 import { checkNpmUpdate, formatUpdateNotice } from "../services/version-check.js";
 
 const AUTH_ATTEMPTED_FILE = join(homedir(), ".codex", "supermemory", ".auth-attempted");
+const AUTH_RETRY_MS = 10 * 60_000;
 const UPDATE_COMMAND = "npx codex-supermemory@latest install";
+
+function hasRecentAuthAttempt(): boolean {
+  try {
+    return Date.now() - statSync(AUTH_ATTEMPTED_FILE).mtimeMs < AUTH_RETRY_MS;
+  } catch {
+    return false;
+  }
+}
+
+function startAuthBackground(): void {
+  const hookDir = dirname(process.argv[1] || "");
+  const script = join(hookDir, "auth-background.js");
+  const child = spawn(process.execPath, [script], {
+    detached: true,
+    stdio: "ignore",
+    windowsHide: true,
+  });
+  child.unref();
+}
 
 interface CodexHookPayload {
   session_id?: string;
@@ -46,30 +66,22 @@ async function main() {
   }
 
   if (!isConfigured()) {
-    const alreadyAttempted = existsSync(AUTH_ATTEMPTED_FILE);
-    if (!alreadyAttempted) {
+    if (!hasRecentAuthAttempt()) {
       try {
         mkdirSync(dirname(AUTH_ATTEMPTED_FILE), { recursive: true });
         writeFileSync(AUTH_ATTEMPTED_FILE, new Date().toISOString());
       } catch {}
-
-      try {
-        await startAuthFlow();
-        reloadApiKey();
-        try { unlinkSync(AUTH_ATTEMPTED_FILE); } catch {}
-      } catch {
-        exitWithContext(
-          "[SUPERMEMORY] Memory is installed but NOT active — missing API key.\n" +
-          `Visit: ${AUTH_BASE_URL}\n` +
-          "Run /supermemory-login to authenticate."
-        );
-      }
-    } else {
+      startAuthBackground();
       exitWithContext(
-        "[SUPERMEMORY] Memory is installed but NOT active — missing API key.\n" +
-        "Run /supermemory-login to authenticate."
+        "[SUPERMEMORY] Memory is installed but not connected. I opened the login page in your browser. " +
+        "Complete login there, then continue in Codex. You can also run /supermemory-login manually."
       );
     }
+
+    exitWithContext(
+      "[SUPERMEMORY] Memory is installed but not connected. A login page was opened recently. " +
+      "Complete login there, or run /supermemory-login to authenticate."
+    );
   }
 
   let payload: CodexHookPayload = {};

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -85,10 +85,21 @@ function saveCredentials(apiKey: string, apiBaseUrl?: string): void {
   );
 }
 
-export function startAuthFlow(): Promise<string> {
-  return new Promise((resolve, reject) => {
+export interface AuthSession {
+  authUrl: string;
+  callback: () => Promise<string>;
+}
+
+export function createAuthSession(): Promise<AuthSession> {
+  return new Promise((resolveSession, rejectSession) => {
     let resolved = false;
     const stateToken = randomBytes(16).toString("hex");
+    let resolveAuth: (apiKey: string) => void;
+    let rejectAuth: (error: Error) => void;
+    const result = new Promise<string>((resolve, reject) => {
+      resolveAuth = resolve;
+      rejectAuth = reject;
+    });
 
     const server = createServer((req: IncomingMessage, res: ServerResponse) => {
       const url = new URL(req.url || "/", "http://localhost");
@@ -113,7 +124,7 @@ export function startAuthFlow(): Promise<string> {
           resolved = true;
           clearTimeout(timer);
           server.close();
-          resolve(apiKey);
+          resolveAuth(apiKey);
         } else {
           res.writeHead(400, { "Content-Type": "text/html" });
           res.end(AUTH_ERROR_HTML);
@@ -124,8 +135,6 @@ export function startAuthFlow(): Promise<string> {
       }
     });
 
-    // Listen on an ephemeral port to avoid conflicts; embed the state token in
-    // the callback URL so the console redirects it back through the redirect.
     server.listen(0, "127.0.0.1", () => {
       const { port } = server.address() as AddressInfo;
       const callbackUrl = `http://127.0.0.1:${port}/callback?state=${stateToken}`;
@@ -138,29 +147,32 @@ export function startAuthFlow(): Promise<string> {
         cli_version: "1.0.0",
       });
       const authUrl = `${AUTH_BASE_URL}?${params.toString()}`;
-      openUrl(authUrl).catch((error) => {
-        if (!resolved) {
-          clearTimeout(timer);
-          server.close();
-          reject(new Error(`Failed to open browser: ${error.message}`));
-        }
+      resolveSession({
+        authUrl,
+        callback: () => result,
       });
     });
 
     server.on("error", (err) => {
       if (!resolved) {
         clearTimeout(timer);
-        reject(new Error(`Failed to start auth server: ${err.message}`));
+        rejectSession(new Error(`Failed to start auth server: ${err.message}`));
+        rejectAuth(new Error(`Failed to start auth server: ${err.message}`));
       }
     });
 
     const timer = setTimeout(() => {
       if (!resolved) {
         server.close();
-        reject(new Error("AUTH_TIMEOUT"));
+        rejectAuth(new Error("AUTH_TIMEOUT"));
       }
     }, AUTH_TIMEOUT);
   });
 }
 
+export async function startAuthFlow(): Promise<string> {
+  const session = await createAuthSession();
+  await openUrl(session.authUrl);
+  return session.callback();
+}
 export { AUTH_BASE_URL, CREDENTIALS_FILE };


### PR DESCRIPTION
## Summary

- Start Codex Supermemory OAuth from a detached background helper when hooks detect an unauthenticated install.
- Return an immediate `[SUPERMEMORY]` reminder to Codex instead of blocking the hook while OAuth completes.