### PR TITLE
feat: read legacy Cursor memories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-supermemory",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-supermemory",
-      "version": "1.0.10",
+      "version": "1.0.11",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-supermemory",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Persistent memory for OpenAI Codex CLI — powered by Supermemory",
   "type": "module",
   "main": "dist/cli.js",

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,7 @@ import { homedir } from "node:os";
 import { loadCredentialData, loadCredentials } from "./services/auth.js";
 
 export const CONFIG_FILE = join(homedir(), ".codex", "supermemory.json");
-export const PLUGIN_VERSION = "1.0.10";
+export const PLUGIN_VERSION = "1.0.11";
 export const DEFAULT_BASE_URL = "https://api.supermemory.ai";
 
 export interface CustomContainer {

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -135,7 +135,7 @@ export function startAuthFlow(): Promise<string> {
         hostname: `codex - ${hostname()}`,
         os: `${platform()}-${arch()}`,
         cwd: process.cwd(),
-        cli_version: "1.0.0",
+        cli_version: "1.0.11",
       });
       const authUrl = `${AUTH_BASE_URL}?${params.toString()}`;
       openUrl(authUrl).catch((error) => {

--- a/src/services/client.ts
+++ b/src/services/client.ts
@@ -75,7 +75,7 @@ export interface ProfileWithSearchResult {
 export const AGENT_ENTITY_CONTEXT = `Shared coding-agent memory for one software repository.
 
 RULES:
-- Preserve durable context that helps Claude Code, Codex, or OpenCode continue the work
+- Preserve durable context that helps Claude Code, Codex, OpenCode, or Cursor continue the work
 - Condense assistant responses into decisions, outcomes, and reusable knowledge
 - Keep user preferences and project facts concise and independently understandable
 

--- a/src/services/tags.ts
+++ b/src/services/tags.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { execSync } from "node:child_process";
 import { existsSync, readFileSync, realpathSync } from "node:fs";
-import { hostname, homedir } from "node:os";
+import { hostname, homedir, userInfo } from "node:os";
 import { basename, dirname, join, resolve, sep } from "node:path";
 import { CONFIG } from "../config.js";
 
@@ -263,6 +263,63 @@ function loadLegacyOpenCodeConfig(): {
   return null;
 }
 
+function loadLegacyCursorConfig(directory: string): {
+  repoContainerTag?: string;
+  userContainerTag?: string;
+  projectContainerTag?: string;
+} {
+  let globalConfig: {
+    repoContainerTag?: string;
+    userContainerTag?: string;
+    projectContainerTag?: string;
+  } | null = null;
+  try {
+    const configPath = join(
+      homedir(),
+      ".config",
+      "cursor",
+      "supermemory.json",
+    );
+    if (existsSync(configPath)) {
+      globalConfig = JSON.parse(readFileSync(configPath, "utf-8")) as {
+        repoContainerTag?: string;
+        userContainerTag?: string;
+        projectContainerTag?: string;
+      };
+    }
+  } catch {}
+
+  let projectConfig: {
+    repoContainerTag?: string;
+    userContainerTag?: string;
+    projectContainerTag?: string;
+  } | null = null;
+  let current = resolve(directory);
+  while (true) {
+    try {
+      const configPath = join(
+        current,
+        ".cursor",
+        ".supermemory",
+        "config.json",
+      );
+      if (existsSync(configPath)) {
+        projectConfig = JSON.parse(readFileSync(configPath, "utf-8")) as {
+          repoContainerTag?: string;
+          userContainerTag?: string;
+          projectContainerTag?: string;
+        };
+        break;
+      }
+    } catch {}
+    const parent = dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+
+  return { ...(globalConfig ?? {}), ...(projectConfig ?? {}) };
+}
+
 export function sanitizeRepoName(name: string): string {
   const sanitized = name
     .toLowerCase()
@@ -316,7 +373,10 @@ export function getProjectIdentity(directory: string): string {
 export function getProjectTag(directory: string): string {
   return (
     loadClaudeProjectConfig(directory)?.repoContainerTag ||
+    process.env.SUPERMEMORY_REPO_TAG ||
+    loadLegacyCursorConfig(directory).repoContainerTag ||
     CONFIG.projectContainerTag ||
+    loadLegacyOpenCodeConfig()?.projectContainerTag ||
     getGeneratedProjectTag(directory)
   );
 }
@@ -377,6 +437,26 @@ export function getLegacyOpenCodeProjectTags(directory: string): string[] {
   ]);
 }
 
+export function getLegacyCursorUserTags(directory: string): string[] {
+  const config = loadLegacyCursorConfig(directory);
+  const identity =
+    config.userContainerTag ||
+    process.env.SUPERMEMORY_USER_TAG ||
+    process.env.CURSOR_USER_EMAIL ||
+    getGitEmail(directory) ||
+    `${hostname()}_${userInfo().username}`;
+  return [`cursor_user_${sha256(identity)}`];
+}
+
+export function getLegacyCursorProjectTags(directory: string): string[] {
+  const config = loadLegacyCursorConfig(directory);
+  const identity =
+    config.projectContainerTag ||
+    process.env.SUPERMEMORY_PROJECT_TAG ||
+    getProjectBasePath(directory);
+  return [`cursor_project_${sha256(identity)}`];
+}
+
 function uniqueTags(tags: Array<string | null | undefined>): string[] {
   return [
     ...new Set(
@@ -400,6 +480,7 @@ export function getPersonalReadTags(directory: string): string[] {
     `claudecode_project_${projectHash}`,
     ...getLegacyCodexUserTags(directory),
     ...getLegacyOpenCodeUserTags(directory),
+    ...getLegacyCursorUserTags(directory),
   ]);
 }
 
@@ -410,6 +491,7 @@ export function getProjectReadTags(directory: string): string[] {
     getLegacyGeneratedProjectTag(directory),
     ...getLegacyCodexProjectTags(directory),
     ...getLegacyOpenCodeProjectTags(directory),
+    ...getLegacyCursorProjectTags(directory),
   ]);
 }
 

--- a/test/unit.mjs
+++ b/test/unit.mjs
@@ -131,7 +131,7 @@ describe("container tags", () => {
     );
   });
 
-  test("uses unified tags and includes legacy Claude, Codex, and OpenCode reads", (t) => {
+  test("uses unified tags and includes all agent legacy reads", (t) => {
     const tmpDir = makeTmpDir();
     t.after(() => rmSync(tmpDir, { recursive: true, force: true }));
     const repoDir = join(tmpDir, "Example Project");
@@ -170,12 +170,16 @@ describe("container tags", () => {
       `claudecode_project_${pathHash}`,
       `codex_user_${hash16("test@example.com")}`,
       `opencode_user_${hash16("test@example.com")}`,
+      `cursor_user_${hash16("test@example.com")}`,
     ]);
     assert.deepEqual(tags.projectReads, [
       canonicalTag,
       "repo_example_project",
       `codex_project_${pathHash}`,
-      `opencode_project_${pathHash}`,
+      ...[...new Set([hash16(repoDir), pathHash])].map(
+        (hash) => `opencode_project_${hash}`,
+      ),
+      `cursor_project_${pathHash}`,
     ]);
   });
 


### PR DESCRIPTION
Adds Cursor legacy-tag reads and shared repository identity handling to Codex without changing canonical writes. Bumps the package and lockfile to 1.0.11.

Tests: unit tests and build.
