### PR TITLE
fix: honor logout marker at session start

### DIFF
--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -11,6 +11,7 @@ import { getSeenFacts, addSeenFacts } from "../services/factCache.js";
 import { checkNpmUpdate, formatUpdateNotice } from "../services/version-check.js";
 
 const AUTH_ATTEMPTED_FILE = join(homedir(), ".codex", "supermemory", ".auth-attempted");
+const LOGGED_OUT_FILE = join(homedir(), ".codex", "supermemory", ".logged-out");
 const UPDATE_COMMAND = "npx codex-supermemory@latest install";
 
 interface CodexHookPayload {
@@ -46,6 +47,11 @@ async function main() {
   }
 
   if (!isConfigured()) {
+    if (existsSync(LOGGED_OUT_FILE)) {
+      log("session-start: logged out marker present, skipping browser auth");
+      exitWithContext("");
+    }
+
     const alreadyAttempted = existsSync(AUTH_ATTEMPTED_FILE);
     if (!alreadyAttempted) {
       try {

--- a/test/unit.mjs
+++ b/test/unit.mjs
@@ -633,6 +633,30 @@ describe("recall hook output envelope", () => {
   });
 });
 
+// ─── session-start hook logout behavior ──────────────────────────────────────
+
+describe("session-start hook logout behavior", () => {
+  const sessionStartBin = fileURLToPath(new URL("../dist/hooks/session-start.js", import.meta.url));
+
+  test("exits silently after explicit logout marker", (t) => {
+    const tmpDir = makeTmpDir();
+    const supermemoryDir = join(tmpDir, ".codex", "supermemory");
+    mkdirSync(supermemoryDir, { recursive: true });
+    writeFileSync(join(supermemoryDir, ".logged-out"), new Date().toISOString());
+    t.after(() => rmSync(tmpDir, { recursive: true, force: true }));
+
+    const result = spawnSync("node", [sessionStartBin], {
+      input: JSON.stringify({ session_id: "s1" }),
+      env: { ...process.env, HOME: tmpDir, USERPROFILE: tmpDir, SUPERMEMORY_CODEX_API_KEY: "" },
+      encoding: "utf-8",
+      timeout: 5_000,
+    });
+
+    assert.equal(result.status, 0);
+    assert.equal(result.stdout, "");
+  });
+});
+
 // ─── flush hook — Stop payload handling ──────────────────────────────────────
 
 describe("flush hook Stop payload", () => {


### PR DESCRIPTION
## Summary

Prevents the SessionStart hook from opening the browser authentication flow after a user has explicitly logged out.

The hook now honors `~/.codex/supermemory/.logged-out`, matching the existing recall-hook behavior.

## Testing

- `npm test` — 58 passing

Fixes #28 
