### PR TITLE
fix(status): report actual recall and capture configuration

### DIFF
--- a/src/skills/status.ts
+++ b/src/skills/status.ts
@@ -39,6 +39,15 @@ function getDevTlsHint(): string | null {
   return "Dev API TLS: set NODE_EXTRA_CA_CERTS to your Portless CA before starting Codex.";
 }
 
+function getRecallStatus(): string {
+  return CONFIG.autoRecallEveryPrompt ? "every prompt" : "manual";
+}
+
+function getCaptureStatus(): string {
+  if (CONFIG.captureEveryNTurns <= 0) return "disabled";
+  return `every ${CONFIG.captureEveryNTurns} turn${CONFIG.captureEveryNTurns === 1 ? "" : "s"}`;
+}
+
 async function fetchJson(path: string): Promise<unknown | null> {
   const apiKey = getApiKeyValue();
   if (!apiKey) return null;
@@ -103,8 +112,8 @@ async function main(): Promise<void> {
   lines.push(`API key: ${maskKey(apiKey)} (${getKeySource()})`);
   lines.push(`API URL: ${API_URL}`);
   lines.push(`Memory scope: one project container with metadata scopes`);
-  lines.push(`Recall mode: auto-recall on every prompt`);
-  lines.push(`Capture cadence: ${CONFIG.autoSaveEveryTurns > 0 ? `every ${CONFIG.autoSaveEveryTurns} turn${CONFIG.autoSaveEveryTurns === 1 ? "" : "s"} + session end` : "session end only"}`);
+  lines.push(`Recall: ${getRecallStatus()}`);
+  lines.push(`Capture: ${getCaptureStatus()}`);
   lines.push(`Project container: ${tags.canonical}`);
   lines.push(`Reads (including legacy): ${tags.allReads.join(", ")}`);
 

--- a/src/skills/status.ts
+++ b/src/skills/status.ts
@@ -39,12 +39,12 @@ function getDevTlsHint(): string | null {
   return "Dev API TLS: set NODE_EXTRA_CA_CERTS to your Portless CA before starting Codex.";
 }
 
-function getRecallStatus(): string {
-  return CONFIG.autoRecallEveryPrompt ? "every prompt" : "manual";
+function getAutoRecallStatus(): string {
+  return CONFIG.autoRecallEveryPrompt ? "every prompt" : "off";
 }
 
-function getCaptureStatus(): string {
-  if (CONFIG.captureEveryNTurns <= 0) return "disabled";
+function getAutoCaptureStatus(): string {
+  if (CONFIG.captureEveryNTurns <= 0) return "off";
   return `every ${CONFIG.captureEveryNTurns} turn${CONFIG.captureEveryNTurns === 1 ? "" : "s"}`;
 }
 
@@ -112,8 +112,8 @@ async function main(): Promise<void> {
   lines.push(`API key: ${maskKey(apiKey)} (${getKeySource()})`);
   lines.push(`API URL: ${API_URL}`);
   lines.push(`Memory scope: one project container with metadata scopes`);
-  lines.push(`Recall: ${getRecallStatus()}`);
-  lines.push(`Capture: ${getCaptureStatus()}`);
+  lines.push(`Auto-recall: ${getAutoRecallStatus()}`);
+  lines.push(`Auto-capture: ${getAutoCaptureStatus()}`);
   lines.push(`Project container: ${tags.canonical}`);
   lines.push(`Reads (including legacy): ${tags.allReads.join(", ")}`);
 

--- a/test/unit.mjs
+++ b/test/unit.mjs
@@ -752,6 +752,18 @@ describe("skill scripts: search/add/save/forget/status/logout", () => {
     });
   }
 
+  function runStatusWithConfig(t, config) {
+    const tmpDir = makeTmpDir();
+    const codexDir = join(tmpDir, ".codex");
+    mkdirSync(codexDir, { recursive: true });
+    writeFileSync(join(codexDir, "supermemory.json"), JSON.stringify(config));
+    t.after(() => rmSync(tmpDir, { recursive: true, force: true }));
+    return spawnSync("node", [statusBin], {
+      env: { PATH: process.env.PATH, HOME: tmpDir, USERPROFILE: tmpDir, SUPERMEMORY_CODEX_API_KEY: "" },
+      encoding: "utf-8",
+    });
+  }
+
   // Run a script with a (fake) API key but no network. We expect arg-parsing
   // branches (missing query/content) to short-circuit before any network call.
   function runSkillNoArgs(t, bin) {
@@ -794,6 +806,31 @@ describe("skill scripts: search/add/save/forget/status/logout", () => {
     assert.equal(result.status, 0);
     assert.match(result.stdout, /Connected: no/);
     assert.match(result.stdout, /supermemory-login/);
+  });
+
+  test("status reports manual recall when auto recall is disabled", (t) => {
+    const result = runStatusWithConfig(t, { autoRecallEveryPrompt: false, captureEveryNTurns: 0 });
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /Recall: manual/);
+  });
+
+  test("status reports every-prompt recall when auto recall is enabled", (t) => {
+    const result = runStatusWithConfig(t, { autoRecallEveryPrompt: true, captureEveryNTurns: 0 });
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /Recall: every prompt/);
+  });
+
+  test("status reports disabled capture when captureEveryNTurns is zero", (t) => {
+    const result = runStatusWithConfig(t, { autoRecallEveryPrompt: false, captureEveryNTurns: 0 });
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /Capture: disabled/);
+  });
+
+  test("status reports configured capture cadence from captureEveryNTurns", (t) => {
+    const result = runStatusWithConfig(t, { autoRecallEveryPrompt: false, captureEveryNTurns: 5, autoSaveEveryTurns: 3 });
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /Capture: every 5 turns/);
+    assert.doesNotMatch(result.stdout, /every 3 turns/);
   });
 
   test("logout removes saved credentials and config apiKey", (t) => {

--- a/test/unit.mjs
+++ b/test/unit.mjs
@@ -808,28 +808,28 @@ describe("skill scripts: search/add/save/forget/status/logout", () => {
     assert.match(result.stdout, /supermemory-login/);
   });
 
-  test("status reports manual recall when auto recall is disabled", (t) => {
+  test("status reports auto-recall off when auto recall is disabled", (t) => {
     const result = runStatusWithConfig(t, { autoRecallEveryPrompt: false, captureEveryNTurns: 0 });
     assert.equal(result.status, 0);
-    assert.match(result.stdout, /Recall: manual/);
+    assert.match(result.stdout, /Auto-recall: off/);
   });
 
-  test("status reports every-prompt recall when auto recall is enabled", (t) => {
+  test("status reports every-prompt auto-recall when enabled", (t) => {
     const result = runStatusWithConfig(t, { autoRecallEveryPrompt: true, captureEveryNTurns: 0 });
     assert.equal(result.status, 0);
-    assert.match(result.stdout, /Recall: every prompt/);
+    assert.match(result.stdout, /Auto-recall: every prompt/);
   });
 
-  test("status reports disabled capture when captureEveryNTurns is zero", (t) => {
+  test("status reports auto-capture off when captureEveryNTurns is zero", (t) => {
     const result = runStatusWithConfig(t, { autoRecallEveryPrompt: false, captureEveryNTurns: 0 });
     assert.equal(result.status, 0);
-    assert.match(result.stdout, /Capture: disabled/);
+    assert.match(result.stdout, /Auto-capture: off/);
   });
 
-  test("status reports configured capture cadence from captureEveryNTurns", (t) => {
+  test("status reports configured auto-capture cadence from captureEveryNTurns", (t) => {
     const result = runStatusWithConfig(t, { autoRecallEveryPrompt: false, captureEveryNTurns: 5, autoSaveEveryTurns: 3 });
     assert.equal(result.status, 0);
-    assert.match(result.stdout, /Capture: every 5 turns/);
+    assert.match(result.stdout, /Auto-capture: every 5 turns/);
     assert.doesNotMatch(result.stdout, /every 3 turns/);
   });
 


### PR DESCRIPTION
## Summary

Fixes incorrect configuration reporting in `/supermemory-status`.

### Changes

- Read recall status from `CONFIG.autoRecallEveryPrompt`
- Read capture frequency from `CONFIG.captureEveryNTurns`
- Remove usage of deprecated `autoSaveEveryTurns` from status output
- Add tests for enabled/disabled recall and capture reporting

## Problem

Fresh installs incorrectly reported:

- Recall on every prompt
- Capture every three turns

even when the default configuration disables both.

## Expected Behavior

The status command now accurately reflects the active runtime configuration, including disabled states and configured capture intervals.

## Testing

- Added/updated unit tests
- Verified fresh-install configuration
- Verified non-default configurations
- Ran the full test suite successfully

Issue fixed: #31 