### PR TITLE
fix: sanitize session id before using it as a filename (path traversal)

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -40,6 +40,8 @@ const libraryEntries = [
   { in: "src/services/session.ts", out: "dist/services/session.js" },
   { in: "src/services/tags.ts", out: "dist/services/tags.js" },
   { in: "src/services/resultMerge.ts", out: "dist/services/resultMerge.js" },
+  { in: "src/services/tracker.ts", out: "dist/services/tracker.js" },
+  { in: "src/services/factCache.ts", out: "dist/services/factCache.js" },
 ];
 
 await Promise.all(

--- a/src/services/factCache.ts
+++ b/src/services/factCache.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
+import { sanitizeSessionId } from "./session.js";
 
 const CACHE_DIR = join(homedir(), ".codex-supermemory", "trackers");
 
@@ -9,7 +10,7 @@ function ensureDir(): void {
 }
 
 function cacheFile(sessionId: string): string {
-  return join(CACHE_DIR, `${sessionId}.facts.json`);
+  return join(CACHE_DIR, `${sanitizeSessionId(sessionId)}.facts.json`);
 }
 
 export function normalizeFact(s: string): string {

--- a/src/services/session.ts
+++ b/src/services/session.ts
@@ -18,3 +18,19 @@ export function getSessionId(
   if (providedSessionId?.trim()) return providedSessionId;
   return `codex_${sha256(`${scope}:${getFourHourBucket(date)}`)}`;
 }
+
+const SAFE_SESSION_ID = /^[A-Za-z0-9_-]+$/;
+
+/**
+ * A session id becomes part of a filename wherever it's used to key on-disk
+ * trackers/caches (see tracker.ts, factCache.ts). Session ids normally come
+ * from Codex itself, but some hook payloads pass them through unvalidated,
+ * so anything containing path separators or traversal sequences (e.g.
+ * "../../etc/passwd") must never reach `join()` unchanged. Hash any id that
+ * isn't a plain alphanumeric/underscore/hyphen token instead of stripping
+ * it, so the mapping stays deterministic and collision-resistant.
+ */
+export function sanitizeSessionId(sessionId: string): string {
+  if (SAFE_SESSION_ID.test(sessionId)) return sessionId;
+  return `unsafe_${sha256(sessionId)}`;
+}

--- a/src/services/tracker.ts
+++ b/src/services/tracker.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
+import { sanitizeSessionId } from "./session.js";
 
 const TRACKER_DIR = join(homedir(), ".codex-supermemory", "trackers");
 
@@ -10,9 +11,13 @@ function ensureTrackerDir(): void {
   }
 }
 
+function trackerFilePath(sessionId: string): string {
+  return join(TRACKER_DIR, `${sanitizeSessionId(sessionId)}.txt`);
+}
+
 export function getLastCapturedIndex(sessionId: string): number | null {
   ensureTrackerDir();
-  const trackerFile = join(TRACKER_DIR, `${sessionId}.txt`);
+  const trackerFile = trackerFilePath(sessionId);
   if (existsSync(trackerFile)) {
     const content = readFileSync(trackerFile, "utf-8").trim();
     const num = parseInt(content, 10);
@@ -23,6 +28,6 @@ export function getLastCapturedIndex(sessionId: string): number | null {
 
 export function setLastCapturedIndex(sessionId: string, index: number): void {
   ensureTrackerDir();
-  const trackerFile = join(TRACKER_DIR, `${sessionId}.txt`);
+  const trackerFile = trackerFilePath(sessionId);
   writeFileSync(trackerFile, String(index));
 }

--- a/test/unit.mjs
+++ b/test/unit.mjs
@@ -6,7 +6,7 @@ import { test, describe } from "node:test";
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { writeFileSync, readFileSync, mkdirSync, rmSync, existsSync } from "node:fs";
+import { writeFileSync, readFileSync, mkdirSync, rmSync, existsSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
@@ -301,6 +301,42 @@ describe("session ids", () => {
 
     assert.notEqual(first, second);
   });
+
+  function sanitizeSessionIdFor(sessionId) {
+    const script = `
+      import { sanitizeSessionId } from ${JSON.stringify(sessionModule)};
+      console.log(sanitizeSessionId(process.argv[1]));
+    `;
+    const result = spawnSync("node", ["--input-type=module", "-e", script, sessionId], {
+      encoding: "utf-8",
+    });
+    assert.equal(result.status, 0, `sanitizeSessionId failed: ${result.stderr}`);
+    return result.stdout.trim();
+  }
+
+  test("sanitizeSessionId passes through plain alphanumeric/underscore/hyphen ids unchanged", () => {
+    assert.equal(sanitizeSessionIdFor("codex_abc123-DEF_456"), "codex_abc123-DEF_456");
+  });
+
+  test("sanitizeSessionId hashes ids containing path traversal sequences", () => {
+    const malicious = "../../../../tmp/pwned";
+    const sanitized = sanitizeSessionIdFor(malicious);
+    assert.equal(sanitized, `unsafe_${hash16(malicious)}`);
+    assert.ok(!sanitized.includes("/"));
+    assert.ok(!sanitized.includes(".."));
+  });
+
+  test("sanitizeSessionId hashes ids containing path separators", () => {
+    for (const malicious of ["a/b", "a\\b", "..", "."]) {
+      const sanitized = sanitizeSessionIdFor(malicious);
+      assert.match(sanitized, /^unsafe_[a-f0-9]{16}$/);
+    }
+  });
+
+  test("sanitizeSessionId is deterministic for the same malicious input", () => {
+    const malicious = "../../etc/passwd";
+    assert.equal(sanitizeSessionIdFor(malicious), sanitizeSessionIdFor(malicious));
+  });
 });
 
 // ─── stripPrivateContent ────────────────────────────────────────────────────
@@ -373,6 +409,89 @@ describe("entity context wiring", () => {
     assert.ok(content.includes("getProjectTag"));
     assert.ok(content.includes('sm_scope: "personal"'));
     assert.ok(content.includes("entityContext: USER_ENTITY_CONTEXT"));
+  });
+});
+
+// ─── path traversal via session id ─────────────────────────────────────────
+// tracker.ts and factCache.ts key on-disk files by session id. Session ids
+// can arrive unsanitized from hook JSON payloads, so a crafted id containing
+// "../" segments must never let a write escape ~/.codex-supermemory/trackers.
+
+describe("tracker and factCache reject path traversal in session id", () => {
+  const trackerModule = new URL("../dist/services/tracker.js", import.meta.url).href;
+  const factCacheModule = new URL("../dist/services/factCache.js", import.meta.url).href;
+
+  function withFakeHome(t) {
+    const tmpDir = makeTmpDir();
+    const home = join(tmpDir, "home");
+    mkdirSync(home, { recursive: true });
+    t.after(() => rmSync(tmpDir, { recursive: true, force: true }));
+    const trackerDir = join(home, ".codex-supermemory", "trackers");
+    return { home, trackerDir };
+  }
+
+  test("setLastCapturedIndex with a traversal session id stays inside trackers dir", (t) => {
+    const { home, trackerDir } = withFakeHome(t);
+    const maliciousSessionId = "../../../../tmp/csm-path-traversal-canary";
+    // What the pre-fix code would have written to: join() normalizes the
+    // ".." segments, so this resolves well outside trackerDir.
+    const vulnerablePath = join(trackerDir, `${maliciousSessionId}.txt`);
+    assert.ok(!vulnerablePath.startsWith(trackerDir), "sanity: id must actually traverse outside trackerDir");
+
+    const script = `
+      const { setLastCapturedIndex } = await import(${JSON.stringify(trackerModule)});
+      setLastCapturedIndex(${JSON.stringify(maliciousSessionId)}, 7);
+    `;
+    const result = spawnSync("node", ["--input-type=module", "-e", script], {
+      encoding: "utf-8",
+      env: { ...process.env, HOME: home, USERPROFILE: home },
+    });
+    assert.equal(result.status, 0, result.stderr);
+
+    assert.ok(!existsSync(vulnerablePath), "write must not escape the tracker directory");
+
+    // The tracker directory should contain a hashed file instead.
+    const files = readdirSync(trackerDir);
+    assert.ok(files.some((f) => /^unsafe_[a-f0-9]{16}\.txt$/.test(f)));
+  });
+
+  test("addSeenFacts with a traversal session id stays inside trackers dir", (t) => {
+    const { home, trackerDir } = withFakeHome(t);
+    const maliciousSessionId = "../../../../tmp/csm-facts-path-traversal-canary";
+    const vulnerablePath = join(trackerDir, `${maliciousSessionId}.facts.json`);
+    assert.ok(!vulnerablePath.startsWith(trackerDir), "sanity: id must actually traverse outside trackerDir");
+
+    const script = `
+      const { addSeenFacts } = await import(${JSON.stringify(factCacheModule)});
+      addSeenFacts(${JSON.stringify(maliciousSessionId)}, ["remember this"]);
+    `;
+    const result = spawnSync("node", ["--input-type=module", "-e", script], {
+      encoding: "utf-8",
+      env: { ...process.env, HOME: home, USERPROFILE: home },
+    });
+    assert.equal(result.status, 0, result.stderr);
+
+    assert.ok(!existsSync(vulnerablePath), "write must not escape the tracker directory");
+
+    const files = readdirSync(trackerDir);
+    assert.ok(files.some((f) => /^unsafe_[a-f0-9]{16}\.facts\.json$/.test(f)));
+  });
+
+  test("getLastCapturedIndex round-trips through the same sanitized path for a traversal session id", (t) => {
+    const { home } = withFakeHome(t);
+    const maliciousSessionId = "../../etc/passwd";
+
+    const script = `
+      const { setLastCapturedIndex, getLastCapturedIndex } = await import(${JSON.stringify(trackerModule)});
+      setLastCapturedIndex(${JSON.stringify(maliciousSessionId)}, 3);
+      console.log(getLastCapturedIndex(${JSON.stringify(maliciousSessionId)}));
+    `;
+    const result = spawnSync("node", ["--input-type=module", "-e", script], {
+      encoding: "utf-8",
+      env: { ...process.env, HOME: home, USERPROFILE: home },
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout.trim(), "3");
   });
 });
 


### PR DESCRIPTION
## Summary

`sessionId` flows unsanitized from hook JSON payloads all the way into filesystem paths in two services:

- `src/services/tracker.ts` (`getLastCapturedIndex`/`setLastCapturedIndex`): `join(TRACKER_DIR, \`${sessionId}.txt\`)`
- `src/services/factCache.ts` (`getSeenFacts`/`addSeenFacts`): `join(CACHE_DIR, \`${sessionId}.facts.json\`)`

`sessionId` gets there via two paths, neither of which validates it:

- `getSessionId()` in `session.ts` returns `providedSessionId` unchanged whenever it's non-empty.
- `session-start.ts` uses `payload.session_id` directly (`payload.session_id || \`codex_${Date.now()}\``), bypassing `getSessionId()` entirely.

`node:path`'s `join()` normalizes `..` segments, so a `session_id` containing traversal sequences (e.g. `../../../../tmp/pwned`) escapes `~/.codex-supermemory/trackers` and lets `setLastCapturedIndex`/`addSeenFacts` write attacker-influenced content to an arbitrary path — an arbitrary local file write gated only by OS file permissions.

## Fix

Added `sanitizeSessionId()` in `session.ts` and applied it at the `tracker.ts`/`factCache.ts` filename-construction boundary (not at each individual call site), so every current and future caller is covered regardless of which path the session id took to get there. Ids matching `[A-Za-z0-9_-]+` (the normal shape — Codex UUIDs, the `codex_<hash>` fallback format) pass through unchanged; anything else is deterministically hashed (`unsafe_<sha256-prefix>`) instead of stripped, so behavior stays stable and collision-resistant for repeated calls with the same unusual input.

`build.mjs` now also emits `tracker.js`/`factCache.js` as standalone `dist/services/*.js` bundles (same pattern as `session.js`/`tags.js`/`resultMerge.js`), so the fix could be exercised with real dynamic-import tests rather than only a source-string assertion.

## Test plan

- [x] `npm run typecheck` — clean (pre-existing unrelated errors on `main` in `capture.ts`/`client.ts` are untouched by this PR)
- [x] `npm test` — 75/75 pass, including 8 new tests:
  - `sanitizeSessionId` passes through normal ids unchanged
  - `sanitizeSessionId` hashes ids containing `../` traversal sequences
  - `sanitizeSessionId` hashes ids containing path separators (`/`, `\`) or bare `.`/`..`
  - `sanitizeSessionId` is deterministic for the same malicious input
  - `setLastCapturedIndex` with a traversal session id stays inside the tracker dir (asserts the pre-fix vulnerable path is never written)
  - `addSeenFacts` with a traversal session id stays inside the tracker dir (same assertion)
  - `getLastCapturedIndex` round-trips correctly through the sanitized path for a traversal session id