### PR TITLE
Use /v3/session for status account info; stop probing account lifecycle endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-supermemory",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "Persistent memory for OpenAI Codex CLI — powered by Supermemory",
   "type": "module",
   "main": "dist/cli.js",

--- a/src/skills/status.ts
+++ b/src/skills/status.ts
@@ -66,38 +66,20 @@ async function fetchJson(path: string): Promise<unknown | null> {
   }
 }
 
-function findAccountInfo(value: unknown): { email?: string; name?: string; userId?: string; orgName?: string } {
-  const seen = new Set<unknown>();
-  const stack = [value];
-  const result: { email?: string; name?: string; userId?: string; orgName?: string } = {};
-
-  while (stack.length > 0) {
-    const item = stack.pop();
-    if (!item || typeof item !== "object" || seen.has(item)) continue;
-    seen.add(item);
-
-    const record = item as Record<string, unknown>;
-    for (const [key, raw] of Object.entries(record)) {
-      const lower = key.toLowerCase();
-      if (!result.email && lower === "email" && typeof raw === "string") result.email = raw;
-      if (!result.name && lower === "name" && typeof raw === "string") result.name = raw;
-      if (!result.userId && (lower === "userid" || lower === "user_id") && typeof raw === "string") result.userId = raw;
-      if (!result.orgName && (lower === "organizationname" || lower === "orgname") && typeof raw === "string") result.orgName = raw;
-
-      if (raw && typeof raw === "object") stack.push(raw);
-    }
-  }
-
-  return result;
-}
-
 async function getAccountInfo(): Promise<{ email?: string; name?: string; userId?: string; orgName?: string }> {
-  for (const path of ["/v3/auth/account/memberships", "/v3/account/memberships", "/v3/me"]) {
-    const data = await fetchJson(path);
-    const info = findAccountInfo(data);
-    if (info.email || info.name || info.userId || info.orgName) return info;
-  }
-  return {};
+  const data = await fetchJson("/v3/session");
+  if (!data || typeof data !== "object") return {};
+
+  const session = data as {
+    user?: { email?: unknown; name?: unknown; id?: unknown };
+    org?: { name?: unknown };
+  };
+  return {
+    email: typeof session.user?.email === "string" ? session.user.email : undefined,
+    name: typeof session.user?.name === "string" ? session.user.name : undefined,
+    userId: typeof session.user?.id === "string" ? session.user.id : undefined,
+    orgName: typeof session.org?.name === "string" ? session.org.name : undefined,
+  };
 }
 
 async function main(): Promise<void> {


### PR DESCRIPTION
## Why?

The `status` skill probed `/v3/auth/account/memberships` (plus two other guessed paths) with the user's API key just to display account info. That endpoint is part of the console's account-deletion flow and is session-only — every API-key request deterministically 403s with `API keys cannot access account lifecycle endpoints`, feeding Sentry issue [SUPERMEMORY-BACKEND-108R](https://supermemory.sentry.io/issues/SUPERMEMORY-BACKEND-108R). Same fix as supermemoryai/opencode-supermemory#68.

## What?

- `getAccountInfo` now calls `GET /v3/session` — the whoami endpoint that works with API-key auth (same one the MCP server uses) — and reads `user.email`/`user.name`/`user.id`/`org.name` directly.
- Removes the generic walk-the-JSON account scraper and the three-endpoint probe list.
- Bumps version to 1.0.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
