### PR TITLE
Prioritize human-memorable capture

### DIFF
--- a/src/services/client.ts
+++ b/src/services/client.ts
@@ -82,9 +82,10 @@ export interface ProfileWithSearchResult {
   error?: string;
 }
 
-export const AGENT_ENTITY_CONTEXT = `Shared coding-agent memory for one software repository.
+export const AGENT_ENTITY_CONTEXT = `Shared coding-agent memory for one software repository. Extract what a human teammate would remember and use later, not a replay of the current terminal state.
 
 RULES:
+- Prefer decisions, constraints, preferences, and lessons that remain useful after the current task
 - Preserve durable context that helps Claude Code, Codex, OpenCode, or Cursor continue the work
 - Condense assistant responses into decisions, outcomes, and reusable knowledge
 - Keep user preferences and project facts concise and independently understandable
@@ -100,6 +101,7 @@ EXTRACT:
 SKIP:
 - Generic assistant suggestions the user did not accept
 - Transient command output and low-value implementation chatter
+- Transient Git state already tracked by the repository: current branch or HEAD, uncommitted file lists, diffs, commit/push status, and in-flight worktree state
 - Granular details that do not help future work`;
 
 export const USER_ENTITY_CONTEXT = AGENT_ENTITY_CONTEXT;

--- a/test/unit.mjs
+++ b/test/unit.mjs
@@ -454,6 +454,8 @@ describe("entity context wiring", () => {
     assert.ok(content.includes("PROJECT_ENTITY_CONTEXT"));
     assert.ok(content.includes("entityContext?: string"));
     assert.ok(content.includes("payload.entityContext = options.entityContext"));
+    assert.match(content, /human teammate would remember/);
+    assert.match(content, /Transient Git state/);
   });
 
   test("automatic capture writes user entity context", () => {


### PR DESCRIPTION
Guide automatic capture toward durable user preferences and decisions instead of transient repository state.
