### PR TITLE
Show update notice outside memory context

### DIFF
--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -121,8 +121,9 @@ async function main() {
 
     if (!profileResult.success) {
       exitWithContext(
-        await updateCheck ?? "",
+        "",
         combineContextParts([
+          await updateCheck,
           "◪ supermemory · profile unavailable; continuing without recalled context",
           markTip(),
         ]),
@@ -138,10 +139,8 @@ This project's memory container: ${tags.canonical}
 
 ${text}
 </supermemory-context>`;
-      exitWithContext(combineContextParts([
-        context,
+      exitWithContext(context, combineContextParts([
         updateNotice,
-      ]), combineContextParts([
         `◪ supermemory · active · ${newFacts.length} ${newFacts.length === 1 ? "memory" : "memories"} loaded for ${tags.projectName}`,
         markTip(),
       ]));
@@ -152,15 +151,19 @@ ${text}
     const activeMessage = storedProfileCount > 0
       ? `◪ supermemory · active · memory context current for ${tags.projectName}`
       : `◪ supermemory · active · no memories saved for ${tags.projectName} yet`;
-    exitWithContext(await updateCheck ?? "", combineContextParts([
+    exitWithContext("", combineContextParts([
+      await updateCheck,
       activeMessage,
       markTip(),
     ]));
   } catch (error) {
     log("session-start: error", { error: String(error) });
     exitWithContext(
-      await updateCheck ?? "",
-      "◪ supermemory · profile unavailable; continuing without recalled context",
+      "",
+      combineContextParts([
+        await updateCheck,
+        "◪ supermemory · profile unavailable; continuing without recalled context",
+      ]),
     );
   }
 }

--- a/src/services/version-check.ts
+++ b/src/services/version-check.ts
@@ -66,8 +66,7 @@ export async function checkNpmUpdate(
 
 export function formatUpdateNotice(info: UpdateInfo): string {
   return [
-    "[SUPERMEMORY UPDATE]",
     `Supermemory update available: v${info.currentVersion} -> v${info.latestVersion}`,
-    `Run: ${info.updateCommand}`,
+    `Run in your terminal: ${info.updateCommand}`,
   ].join("\n");
 }

--- a/test/unit.mjs
+++ b/test/unit.mjs
@@ -651,6 +651,16 @@ describe("browser auth opener", () => {
     assert.ok(sessionStartSource.includes("startAuthFlow(getSessionStartAuthTimeoutMs())"));
     assert.ok(!existsSync(new URL("../src/skills/login.ts", import.meta.url)));
   });
+
+  test("SessionStart keeps update notices out of model context", () => {
+    const sessionStartSource = readFileSync(new URL("../src/hooks/session-start.ts", import.meta.url), "utf-8");
+    const versionCheckSource = readFileSync(new URL("../src/services/version-check.ts", import.meta.url), "utf-8");
+    assert.ok(sessionStartSource.includes("exitWithContext(context, combineContextParts(["));
+    assert.ok(!sessionStartSource.includes("context,\n        updateNotice,"));
+    assert.ok(!sessionStartSource.includes('exitWithContext(await updateCheck ?? ""'));
+    assert.ok(!versionCheckSource.includes("[SUPERMEMORY UPDATE]"));
+    assert.ok(versionCheckSource.includes("Run in your terminal:"));
+  });
 });
 
 // ─── hooks.json format ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- surface update notices through UI-only system messages
- keep update text out of recalled memory context