### PR TITLE
Bump version to 1.0.16 to match published npm package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-supermemory",
-  "version": "1.0.12",
+  "version": "1.0.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-supermemory",
-      "version": "1.0.12",
+      "version": "1.0.16",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-supermemory",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "Persistent memory for OpenAI Codex CLI — powered by Supermemory",
   "type": "module",
   "main": "dist/cli.js",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Align the git repo's version with published reality: bump `package.json` from `1.0.15` to `1.0.16`, and update the `version` fields in `package-lock.json` (which were stale at `1.0.12`) to `1.0.16`.

## Why

The npm package `codex-supermemory` is published at `1.0.16` (dist-tag `latest`, published 2026-09-01T05:36:54Z), but git HEAD still declared `1.0.15` in `package.json`.

Investigation confirmed HEAD is exactly the code that shipped as 1.0.16, so no `1.0.17` bump is warranted:

- npm has never published `1.0.15` — its version list jumps `1.0.14` → `1.0.16`.
- The HEAD commit "Bump version from 1.0.13 to 1.0.15" landed at 2026-09-01T05:36:30Z, ~24s before the 1.0.16 npm publish (2026-09-01T05:36:54Z). The publisher clearly bumped to 1.0.16 at publish time without committing that change back.
- There is no unreleased work on HEAD beyond what was published as 1.0.16.

`bun.lock` does not record a self version field for the workspace root, so it needs no change.

## Notes

- Version-metadata alignment only. No publish; nothing ships until merge + deploy.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f4de0c24-f71f-45e0-b425-939378371c59?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f4de0c24-f71f-45e0-b425-939378371c59&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

