### PR TITLE
fix: forward API key to MCP proxy

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -181,6 +181,7 @@ function mergeConfigToml(enable: boolean, managePet: boolean): boolean {
     mcpServers.supermemory = {
       command: "node",
       args: [MCP_PROXY_SCRIPT],
+      env_vars: ["SUPERMEMORY_CODEX_API_KEY"],
     };
 
     if (managePet) {

--- a/test/unit.mjs
+++ b/test/unit.mjs
@@ -863,6 +863,9 @@ describe("integration: install/uninstall", () => {
     assert.deepEqual(toml.mcp_servers.supermemory.args, [
       join(codexDir, "supermemory", "mcp-proxy.js"),
     ]);
+    assert.deepEqual(toml.mcp_servers.supermemory.env_vars, [
+      "SUPERMEMORY_CODEX_API_KEY",
+    ]);
     assert.equal(toml.tui.pet, "supermemory");
     assert.equal(toml.tui.pet_anchor, "screen-bottom");
     assert.ok(existsSync(join(codexDir, "pets", "supermemory", "pet.json")));


### PR DESCRIPTION
## Summary

- allow-list `SUPERMEMORY_CODEX_API_KEY` for the installed stdio MCP server
- verify the generated MCP configuration in the install integration test

Codex does not forward custom host environment variables to stdio MCP subprocesses unless they are listed in `env_vars`. Without this entry, the proxy reports that Supermemory is unauthenticated even when Codex was launched from a shell containing a valid key.

## Testing

```text
npm test
68 tests passed
```

Fixes #53
