### PR TITLE
fix: unblock npm publish (align to 1.0.17) and point install copy to console.supermemory.ai

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-supermemory",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-supermemory",
-      "version": "1.0.16",
+      "version": "1.0.17",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-supermemory",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "description": "Persistent memory for OpenAI Codex CLI — powered by Supermemory",
   "type": "module",
   "main": "dist/cli.js",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -537,7 +537,7 @@ Next steps:
 
   Or set SUPERMEMORY_CODEX_API_KEY="sm_..." in your shell profile.
 
-  2. Get an API key at: https://app.supermemory.ai/?view=integrations (if needed)
+  2. Get an API key at: https://console.supermemory.ai (if needed)
 
 Optional: Enable debug logging:
   export SUPERMEMORY_DEBUG=true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Two small content changes so the default `npx codex-supermemory` ships the latest main (including merged #54 API-key MCP `env_vars` and #55 MCP merge), and the install copy points at the live console instead of the dead app URL.

1. **Install URL** — `src/cli.ts` install next-steps changed from `https://app.supermemory.ai/?view=integrations` to `https://console.supermemory.ai` (the `?view=integrations` query is an old-app artifact). This matches the URL already used in `src/services/auth.ts`.
2. **Version alignment** — `package.json` and `package-lock.json` bumped `1.0.16` → `1.0.17` to match what is currently published on npm.

## Why the version is 1.0.17, not 1.0.18

`.github/workflows/publish.yml` runs on every push to `main` (except `chore(release):*` commits). It does `npm version patch --no-git-tag-version`, `npm publish`, then commits `chore(release): ${VERSION}` back to main.

- Git was at `1.0.16` but npm latest is already `1.0.17` (the workflow patch-bumped #52's merge). #54/#55 merged afterward but never published, because the workflow tried `1.0.16 → 1.0.17` again and `npm publish` failed since `1.0.17` already exists — the unpublished-main bug.
- Setting git to `1.0.17` here means the workflow will patch-bump to **1.0.18** on merge and publish successfully.
- (If we set git to `1.0.18`, the workflow would publish `1.0.19` — wrong.)

`bun.lock` carries no root version field, so only `package.json` and `package-lock.json` (what `npm version` touches) are updated. The workflow was not modified.

## How this publishes

**Merging this PR to `main` is what publishes `1.0.18`.** The publish workflow bumps and publishes automatically. Do **not** run `npm publish` by hand.

## Tests

`npm test` — all 68 tests pass. No test asserted the old app URL or the old version, so no assertions needed updating.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5b738f9-6625-4bb3-aa3c-36c06dc5962e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5b738f9-6625-4bb3-aa3c-36c06dc5962e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

